### PR TITLE
fix race condition producing error for new user invite

### DIFF
--- a/src/app/(main)/leagues/create/action.ts
+++ b/src/app/(main)/leagues/create/action.ts
@@ -5,6 +5,7 @@ import {
   createDBLeague,
   createDBLeagueSeason,
   createDBLeagueMember,
+  DBLeague,
 } from "@/db/leagues";
 import {
   getDBSportById,
@@ -29,6 +30,7 @@ export interface CreateLeagueFormState {
     leagueVisibility?: string;
     size?: string;
   };
+  leagueId?: string;
 }
 
 export async function createLeagueAction(
@@ -147,8 +149,9 @@ export async function createLeagueAction(
     };
   }
 
+  let dbLeague: DBLeague | undefined = undefined;
   try {
-    await withTransaction(async (tx) => {
+    dbLeague = await withTransaction(async (tx) => {
       const createDBLeagueData = {
         name: parsed.data.name,
         logoUrl: parsed.data.logoUrl,
@@ -202,6 +205,8 @@ export async function createLeagueAction(
 
         throw new Error("Unable to create league member");
       }
+
+      return dbLeague;
     });
   } catch (e: unknown) {
     if (e instanceof Error) {
@@ -215,5 +220,7 @@ export async function createLeagueAction(
     };
   }
 
-  return {};
+  return {
+    leagueId: dbLeague?.id,
+  };
 }

--- a/src/app/(main)/leagues/create/form.tsx
+++ b/src/app/(main)/leagues/create/form.tsx
@@ -17,6 +17,7 @@ import {
   CreateLeagueSchema,
   DEFAULT_LEAGUE_SIZE,
   DEFAULT_PICKS_PER_WEEK,
+  getLeagueHomeUrl,
   LEAGUE_VISIBILITY_VALUES,
   LeagueVisibilities,
   PICK_TYPE_VALUES,
@@ -511,8 +512,7 @@ export function CreateLeagueForm({
               description: "Your league has been successfully created.",
             });
 
-            router.push("/dashboard");
-            router.refresh();
+            router.push(getLeagueHomeUrl(actionResponse.leagueId!));
           })(e);
         }}
       >

--- a/src/app/(main)/profile/form.tsx
+++ b/src/app/(main)/profile/form.tsx
@@ -219,6 +219,7 @@ export default function UpdateProfileForm({
 
             if (postSubmitUrl) {
               router.push(postSubmitUrl);
+              return;
             }
 
             // this is a quick hack to get the profile menu to refetched it's data


### PR DESCRIPTION
Fixes #18.

There was a race condition when new users submitted their profile form where sometimes they would get routed to the invite page twice, causing them to accept the invite twice.

Also snuck in a UX improvement where a user is navigated to their league once they create it.