### PR TITLE
fix invite accept check

### DIFF
--- a/src/app/invites/[id]/page.tsx
+++ b/src/app/invites/[id]/page.tsx
@@ -106,7 +106,8 @@ export default async function InvitesPage({
 
   if (
     new Date() > dbLeague.invite.expiresAt ||
-    dbLeague.invite.acceptedByUserId !== session.user.id
+    (dbLeague.invite.acceptedByUserId &&
+      dbLeague.invite.acceptedByUserId !== session.user.id)
   ) {
     return (
       <ErrorPage


### PR DESCRIPTION
Hopefully final fix for #18 

All invite acceptances were failing because the check for expiration was not considering the use case when invite_accepted_by_user_id was null.