### PR TITLE
Epic: Picks & Scoring

### DIFF
--- a/actions/admin-overrides.test.ts
+++ b/actions/admin-overrides.test.ts
@@ -17,9 +17,11 @@ import {
 } from "@/data/events";
 import { clearLockedPhase, setLockedPhase, updatePhase } from "@/data/phases";
 import { clearLockedTeam, setLockedTeam, updateTeam } from "@/data/teams";
+import { clearPickResultsForEvent } from "@/data/picks";
 import type { Profile } from "@/lib/db/schema/profiles";
 import { ForbiddenError, NotFoundError, UnauthorizedError } from "@/lib/errors";
 import { requireAdminSession } from "@/lib/permissions";
+import { runStandingsRecalcForEvent } from "@/lib/sync/nfl/standings";
 
 vi.mock("@/data/teams", () => ({
   setLockedTeam: vi.fn(),
@@ -44,6 +46,16 @@ vi.mock("@/data/events", () => ({
 
 vi.mock("@/lib/permissions", () => ({
   requireAdminSession: vi.fn(),
+}));
+
+vi.mock("@/data/picks", () => ({
+  clearPickResultsForEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/sync/nfl/standings", () => ({
+  runStandingsRecalcForEvent: vi
+    .fn()
+    .mockResolvedValue({ leaguesAffected: 0, picksRescored: 0 }),
 }));
 
 vi.mock("next/cache", () => ({
@@ -431,6 +443,23 @@ describe("updateEventAction", () => {
     const result = await updateEventAction(validInput());
 
     expect(result).toEqual({ success: false, error: "Event not found" });
+    // Failure path: pick results should NOT be cleared and the recalc
+    // should not run — otherwise an unrelated failure would silently
+    // invalidate pick history.
+    expect(clearPickResultsForEvent).not.toHaveBeenCalled();
+    expect(runStandingsRecalcForEvent).not.toHaveBeenCalled();
+  });
+
+  it("clears pick results and re-runs standings after a successful event update (§8.5)", async () => {
+    await updateEventAction({
+      ...validInput(),
+      status: "final",
+      homeScore: "24",
+      awayScore: "17",
+    });
+
+    expect(clearPickResultsForEvent).toHaveBeenCalledWith(UUID);
+    expect(runStandingsRecalcForEvent).toHaveBeenCalledWith(UUID);
   });
 });
 

--- a/actions/admin-overrides.ts
+++ b/actions/admin-overrides.ts
@@ -11,9 +11,11 @@ import {
   updateOdds,
 } from "@/data/events";
 import { clearLockedPhase, setLockedPhase, updatePhase } from "@/data/phases";
+import { clearPickResultsForEvent } from "@/data/picks";
 import { clearLockedTeam, setLockedTeam, updateTeam } from "@/data/teams";
 import { NotFoundError } from "@/lib/errors";
 import { requireAdminSession } from "@/lib/permissions";
+import { runStandingsRecalcForEvent } from "@/lib/sync/nfl/standings";
 import type { ActionResult } from "@/lib/types";
 import {
   parseDecimal,
@@ -156,6 +158,14 @@ export async function updateEventAction(input: unknown): Promise<ActionResult> {
     }
     throw err;
   }
+
+  // §8.5: when an admin edits an event, picks on it are invalidated
+  // first (so a mid-flight recalc failure leaves the event's picks as
+  // "unscored" rather than carrying a stale cached result), then the
+  // scoped recalc re-scores them and recomputes standings for every
+  // league that has picks on this event.
+  await clearPickResultsForEvent(id);
+  await runStandingsRecalcForEvent(id);
 
   revalidatePath(OVERRIDES_PATH);
   return { success: true, data: undefined };

--- a/actions/admin-overrides.ts
+++ b/actions/admin-overrides.ts
@@ -168,6 +168,11 @@ export async function updateEventAction(input: unknown): Promise<ActionResult> {
   await runStandingsRecalcForEvent(id);
 
   revalidatePath(OVERRIDES_PATH);
+  // Status/score changes on an event affect every league page that
+  // renders that event (my-picks, league-picks, standings). Revalidate
+  // the whole `/leagues` subtree so users don't see a stale `not_started`
+  // row and bypass the pick lock.
+  revalidatePath("/leagues", "layout");
   return { success: true, data: undefined };
 }
 

--- a/actions/picks.test.ts
+++ b/actions/picks.test.ts
@@ -6,10 +6,14 @@ vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
 }));
 
-vi.mock("@/data/events", () => ({
-  getEventsByPhaseWithTeams: vi.fn(),
-  getOddsForEventsWithSportsbook: vi.fn(),
-}));
+vi.mock("@/data/events", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/data/events")>();
+  return {
+    ...original,
+    getEventsByPhaseWithTeams: vi.fn(),
+    getOddsForEventsWithSportsbook: vi.fn(),
+  };
+});
 
 vi.mock("@/data/leagues", () => ({
   getLeagueById: vi.fn(),

--- a/actions/picks.test.ts
+++ b/actions/picks.test.ts
@@ -20,12 +20,13 @@ vi.mock("@/data/leagues", () => ({
 }));
 
 vi.mock("@/data/phases", () => ({
-  getPhaseById: vi.fn(),
+  getPhasesBySeason: vi.fn(),
 }));
 
 vi.mock("@/data/picks", () => ({
   deleteUserPicksForEvents: vi.fn(),
   insertPicks: vi.fn(),
+  getPicksForLeaguePhase: vi.fn(),
 }));
 
 vi.mock("@/data/seasons", () => ({
@@ -53,8 +54,12 @@ import {
   getOddsForEventsWithSportsbook,
 } from "@/data/events";
 import { getLeagueById } from "@/data/leagues";
-import { getPhaseById } from "@/data/phases";
-import { deleteUserPicksForEvents, insertPicks } from "@/data/picks";
+import { getPhasesBySeason } from "@/data/phases";
+import {
+  deleteUserPicksForEvents,
+  getPicksForLeaguePhase,
+  insertPicks,
+} from "@/data/picks";
 import { getSeasonsBySportsLeague } from "@/data/seasons";
 import { getSession } from "@/lib/auth";
 import { assertLeagueMember } from "@/lib/permissions";
@@ -177,12 +182,13 @@ beforeEach(() => {
     updatedAt: new Date(),
   });
   vi.mocked(getLeagueById).mockResolvedValue(straightUpLeague);
-  vi.mocked(getPhaseById).mockResolvedValue(openPhase);
+  vi.mocked(getPhasesBySeason).mockResolvedValue([openPhase]);
   vi.mocked(getSeasonsBySportsLeague).mockResolvedValue([currentSeason]);
   vi.mocked(getAppNow).mockResolvedValue(nowBeforeLock);
   vi.mocked(getOddsForEventsWithSportsbook).mockResolvedValue([]);
   vi.mocked(deleteUserPicksForEvents).mockResolvedValue(undefined);
   vi.mocked(insertPicks).mockResolvedValue([]);
+  vi.mocked(getPicksForLeaguePhase).mockResolvedValue([]);
 });
 
 describe("submitPicksAction", () => {
@@ -218,28 +224,61 @@ describe("submitPicksAction", () => {
     expect(result).toEqual({ success: false, error: "League not found." });
   });
 
-  it("rejects a phase that isn't in the league's range", async () => {
-    vi.mocked(getPhaseById).mockResolvedValueOnce({
-      ...openPhase,
-      seasonType: "postseason",
-      weekNumber: 1,
-    });
+  it("rejects a future phase (§7.1 #2 — current phase only)", async () => {
+    // The submitted phase is Week 4, but Week 3 is the current phase given
+    // `now` is inside Week 3's active window.
+    const futurePhaseId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    vi.mocked(getPhasesBySeason).mockResolvedValueOnce([
+      openPhase,
+      {
+        ...openPhase,
+        id: futurePhaseId,
+        weekNumber: 4,
+        startDate: new Date("2099-09-27T00:00:00Z"),
+        endDate: new Date("2099-10-04T00:00:00Z"),
+        pickLockTime: new Date("2099-09-28T17:00:00Z"),
+      },
+    ]);
     const result = await submitPicksAction({
       leagueId,
-      phaseId,
+      phaseId: futurePhaseId,
       picks: [{ eventId: eventAId, teamId: homeTeamId }],
     });
-    expect(result.success).toBe(false);
     expect(result).toMatchObject({
-      error: expect.stringContaining("isn't part of this league"),
+      success: false,
+      error: expect.stringContaining("current week"),
     });
+    expect(insertPicks).not.toHaveBeenCalled();
   });
 
-  it("rejects a phase whose seasonId doesn't match the current season", async () => {
-    vi.mocked(getPhaseById).mockResolvedValueOnce({
-      ...openPhase,
-      seasonId: "99999999-9999-4999-8999-999999999999",
+  it("rejects a past phase (§7.1 #2 — current phase only)", async () => {
+    // Week 2 already ended; Week 3 is the current phase.
+    const pastPhaseId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    vi.mocked(getPhasesBySeason).mockResolvedValueOnce([
+      {
+        ...openPhase,
+        id: pastPhaseId,
+        weekNumber: 2,
+        startDate: new Date("2099-09-13T00:00:00Z"),
+        endDate: new Date("2099-09-20T00:00:00Z"),
+        pickLockTime: new Date("2099-09-14T17:00:00Z"),
+      },
+      openPhase,
+    ]);
+    const result = await submitPicksAction({
+      leagueId,
+      phaseId: pastPhaseId,
+      picks: [{ eventId: eventAId, teamId: homeTeamId }],
     });
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("current week"),
+    });
+    expect(insertPicks).not.toHaveBeenCalled();
+  });
+
+  it("returns 'No active season' when the league has no current season", async () => {
+    vi.mocked(getSeasonsBySportsLeague).mockResolvedValueOnce([]);
     const result = await submitPicksAction({
       leagueId,
       phaseId,
@@ -247,7 +286,7 @@ describe("submitPicksAction", () => {
     });
     expect(result).toMatchObject({
       success: false,
-      error: expect.stringContaining("isn't in the current season"),
+      error: expect.stringContaining("No active season"),
     });
     expect(insertPicks).not.toHaveBeenCalled();
   });
@@ -297,6 +336,97 @@ describe("submitPicksAction", () => {
     expect(tooMany).toMatchObject({
       success: false,
       error: expect.stringContaining("exactly 2"),
+    });
+  });
+
+  it("locked picks consume the picksPerPhase budget — required = min(picksPerPhase − lockedPickCount, unstartedGames)", async () => {
+    // picksPerPhase=2. Viewer has 1 existing pick on a started game, so
+    // locked quota is used. Required count for this submission = 1.
+    vi.mocked(getEventsByPhaseWithTeams).mockResolvedValue([
+      makeEvent(eventAId, new Date("2099-09-20T00:00:00Z")), // started
+      makeEvent(eventBId, new Date("2099-09-21T16:00:00Z")), // unstarted
+      makeEvent(eventCId, new Date("2099-09-21T16:00:00Z")), // unstarted
+    ]);
+    vi.mocked(getPicksForLeaguePhase).mockResolvedValue([
+      {
+        id: "pick-A",
+        leagueId,
+        userId,
+        phaseId,
+        eventId: eventAId,
+        teamId: homeTeamId,
+        spreadAtLock: null,
+        pickResult: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+
+    // Submitting 2 should be rejected — budget is 2, 1 locked, 1 remaining.
+    const tooMany = await submitPicksAction({
+      leagueId,
+      phaseId,
+      picks: [
+        { eventId: eventBId, teamId: homeTeamId },
+        { eventId: eventCId, teamId: homeTeamId },
+      ],
+    });
+    expect(tooMany).toMatchObject({
+      success: false,
+      error: expect.stringContaining("exactly 1"),
+    });
+
+    // Submitting 1 succeeds.
+    const justRight = await submitPicksAction({
+      leagueId,
+      phaseId,
+      picks: [{ eventId: eventBId, teamId: homeTeamId }],
+    });
+    expect(justRight).toEqual({ success: true, data: undefined });
+  });
+
+  it("rejects submissions when all picks for the phase are already locked (budget exhausted)", async () => {
+    vi.mocked(getEventsByPhaseWithTeams).mockResolvedValue([
+      makeEvent(eventAId, new Date("2099-09-20T00:00:00Z")), // started
+      makeEvent(eventBId, new Date("2099-09-20T00:00:00Z")), // started
+      makeEvent(eventCId, new Date("2099-09-21T16:00:00Z")), // unstarted
+    ]);
+    vi.mocked(getPicksForLeaguePhase).mockResolvedValue([
+      {
+        id: "pick-A",
+        leagueId,
+        userId,
+        phaseId,
+        eventId: eventAId,
+        teamId: homeTeamId,
+        spreadAtLock: null,
+        pickResult: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: "pick-B",
+        leagueId,
+        userId,
+        phaseId,
+        eventId: eventBId,
+        teamId: homeTeamId,
+        spreadAtLock: null,
+        pickResult: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+
+    // picksPerPhase=2, 2 locked → 0 remaining. Any submission is rejected.
+    const result = await submitPicksAction({
+      leagueId,
+      phaseId,
+      picks: [{ eventId: eventCId, teamId: homeTeamId }],
+    });
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("already locked in all your picks"),
     });
   });
 
@@ -454,7 +584,7 @@ describe("submitPicksAction", () => {
     const result = await submitPicksAction({
       leagueId,
       phaseId,
-      picks: [{ eventId: eventAId, teamId: awayTeamId }],
+      picks: [{ eventId: eventAId, teamId: awayTeamId, expectedSpread: 3.5 }],
     });
 
     expect(result).toEqual({ success: true, data: undefined });
@@ -481,11 +611,84 @@ describe("submitPicksAction", () => {
     const result = await submitPicksAction({
       leagueId,
       phaseId,
-      picks: [{ eventId: eventAId, teamId: homeTeamId }],
+      picks: [{ eventId: eventAId, teamId: homeTeamId, expectedSpread: -3.5 }],
     });
     expect(result).toMatchObject({
       success: false,
       error: expect.stringContaining("Spreads aren't available"),
+    });
+    expect(insertPicks).not.toHaveBeenCalled();
+  });
+
+  it("rejects ATS submission with STALE_ODDS when expectedSpread doesn't match current spread", async () => {
+    vi.mocked(getLeagueById).mockResolvedValueOnce(atsLeague);
+    vi.mocked(getEventsByPhaseWithTeams).mockResolvedValue([
+      makeEvent(eventAId, new Date("2099-09-21T16:00:00Z")),
+    ]);
+    // Server-side spread is -7, but client sends -3.5 (loaded the page
+    // before the line moved).
+    vi.mocked(getOddsForEventsWithSportsbook).mockResolvedValueOnce([
+      {
+        id: "odds-1",
+        eventId: eventAId,
+        sportsbookId: "sb-1",
+        sportsbookName: "ESPN Bet",
+        homeSpread: -7,
+        awaySpread: 7,
+        homeMoneyline: -250,
+        awayMoneyline: 210,
+        overUnder: 46,
+        lockedAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+
+    const result = await submitPicksAction({
+      leagueId,
+      phaseId,
+      picks: [{ eventId: eventAId, teamId: homeTeamId, expectedSpread: -3.5 }],
+    });
+    expect(result).toMatchObject({
+      success: false,
+      code: "STALE_ODDS",
+      error: expect.stringContaining("Lines moved"),
+    });
+    expect(insertPicks).not.toHaveBeenCalled();
+  });
+
+  it("rejects ATS submission with STALE_ODDS when expectedSpread is missing", async () => {
+    vi.mocked(getLeagueById).mockResolvedValueOnce(atsLeague);
+    vi.mocked(getEventsByPhaseWithTeams).mockResolvedValue([
+      makeEvent(eventAId, new Date("2099-09-21T16:00:00Z")),
+    ]);
+    vi.mocked(getOddsForEventsWithSportsbook).mockResolvedValueOnce([
+      {
+        id: "odds-1",
+        eventId: eventAId,
+        sportsbookId: "sb-1",
+        sportsbookName: "ESPN Bet",
+        homeSpread: -3.5,
+        awaySpread: 3.5,
+        homeMoneyline: -150,
+        awayMoneyline: 130,
+        overUnder: 45.5,
+        lockedAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+
+    const result = await submitPicksAction({
+      leagueId,
+      phaseId,
+      // No expectedSpread on an ATS league — safer to treat this as
+      // STALE_ODDS so the client refetches instead of freezing blind.
+      picks: [{ eventId: eventAId, teamId: homeTeamId }],
+    });
+    expect(result).toMatchObject({
+      success: false,
+      code: "STALE_ODDS",
     });
     expect(insertPicks).not.toHaveBeenCalled();
   });
@@ -569,7 +772,7 @@ describe("submitPicksAction", () => {
     const first = await submitPicksAction({
       leagueId,
       phaseId,
-      picks: [{ eventId: eventAId, teamId: homeTeamId }],
+      picks: [{ eventId: eventAId, teamId: homeTeamId, expectedSpread: -3.5 }],
     });
     expect(first).toEqual({ success: true, data: undefined });
     expect(insertPicks).toHaveBeenNthCalledWith(
@@ -578,10 +781,13 @@ describe("submitPicksAction", () => {
       {},
     );
 
+    // On the second submission the server's spread is -7. Client sends -7
+    // (it saw the moved line) — e.g. "Take latest odds" — so the refresh
+    // succeeds and freezes -7.
     const second = await submitPicksAction({
       leagueId,
       phaseId,
-      picks: [{ eventId: eventAId, teamId: homeTeamId }],
+      picks: [{ eventId: eventAId, teamId: homeTeamId, expectedSpread: -7 }],
     });
     expect(second).toEqual({ success: true, data: undefined });
     expect(insertPicks).toHaveBeenNthCalledWith(

--- a/actions/picks.test.ts
+++ b/actions/picks.test.ts
@@ -1,0 +1,605 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ForbiddenError } from "@/lib/errors";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/data/events", () => ({
+  getEventsByPhaseWithTeams: vi.fn(),
+  getOddsForEventsWithSportsbook: vi.fn(),
+}));
+
+vi.mock("@/data/leagues", () => ({
+  getLeagueById: vi.fn(),
+}));
+
+vi.mock("@/data/phases", () => ({
+  getPhaseById: vi.fn(),
+}));
+
+vi.mock("@/data/picks", () => ({
+  deleteUserPicksForEvents: vi.fn(),
+  insertPicks: vi.fn(),
+}));
+
+vi.mock("@/data/seasons", () => ({
+  getSeasonsBySportsLeague: vi.fn(),
+}));
+
+vi.mock("@/data/utils", () => ({
+  withTransaction: vi.fn(<T>(fn: (tx: unknown) => Promise<T>) => fn({})),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getSession: vi.fn(),
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  assertLeagueMember: vi.fn(),
+}));
+
+vi.mock("@/lib/simulator", () => ({
+  getAppNow: vi.fn(),
+}));
+
+import {
+  getEventsByPhaseWithTeams,
+  getOddsForEventsWithSportsbook,
+} from "@/data/events";
+import { getLeagueById } from "@/data/leagues";
+import { getPhaseById } from "@/data/phases";
+import { deleteUserPicksForEvents, insertPicks } from "@/data/picks";
+import { getSeasonsBySportsLeague } from "@/data/seasons";
+import { getSession } from "@/lib/auth";
+import { assertLeagueMember } from "@/lib/permissions";
+import { getAppNow } from "@/lib/simulator";
+
+import { submitPicksAction } from "./picks";
+
+const userId = "user-1";
+const session = { user: { id: userId } };
+
+const leagueId = "11111111-1111-4111-8111-111111111111";
+const phaseId = "22222222-2222-4222-8222-222222222222";
+const seasonId = "33333333-3333-4333-8333-333333333333";
+
+const homeTeamId = "44444444-4444-4444-8444-444444444444";
+const awayTeamId = "55555555-5555-4555-8555-555555555555";
+const eventAId = "66666666-6666-4666-8666-666666666666";
+const eventBId = "77777777-7777-4777-8777-777777777777";
+const eventCId = "88888888-8888-4888-8888-888888888888";
+
+const straightUpLeague = {
+  id: leagueId,
+  sportsLeagueId: "nfl-id",
+  name: "Test League",
+  imageUrl: null,
+  startSeasonType: "regular" as const,
+  startWeekNumber: 1,
+  endSeasonType: "regular" as const,
+  endWeekNumber: 18,
+  size: 10,
+  picksPerPhase: 2,
+  pickType: "straight_up" as const,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const atsLeague = {
+  ...straightUpLeague,
+  pickType: "against_the_spread" as const,
+};
+
+const openPhase = {
+  id: phaseId,
+  seasonId,
+  seasonType: "regular" as const,
+  weekNumber: 3,
+  label: "Week 3",
+  startDate: new Date("2099-09-20T00:00:00Z"),
+  endDate: new Date("2099-09-27T00:00:00Z"),
+  pickLockTime: new Date("2099-09-21T17:00:00Z"),
+  lockedAt: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const currentSeason = {
+  id: seasonId,
+  sportsLeagueId: "nfl-id",
+  year: 2099,
+  startDate: new Date("2099-09-01T00:00:00Z"),
+  endDate: new Date("2100-02-28T00:00:00Z"),
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+function makeEvent(
+  id: string,
+  startTime: Date,
+  overrides: { homeTeamId?: string; awayTeamId?: string } = {},
+) {
+  const home = {
+    id: overrides.homeTeamId ?? homeTeamId,
+    sportsLeagueId: "nfl-id",
+    name: "Home",
+    location: "Home",
+    abbreviation: "HOM",
+    logoUrl: null,
+    logoDarkUrl: null,
+    lockedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+  const away = {
+    ...home,
+    id: overrides.awayTeamId ?? awayTeamId,
+    name: "Away",
+    location: "Away",
+    abbreviation: "AWY",
+  };
+  return {
+    id,
+    phaseId,
+    homeTeamId: home.id,
+    awayTeamId: away.id,
+    startTime,
+    status: "not_started" as const,
+    homeScore: null,
+    awayScore: null,
+    lockedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    homeTeam: home,
+    awayTeam: away,
+  };
+}
+
+const nowBeforeLock = new Date("2099-09-20T12:00:00Z");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getSession).mockResolvedValue(
+    session as Awaited<ReturnType<typeof getSession>>,
+  );
+  vi.mocked(assertLeagueMember).mockResolvedValue({
+    id: "m-1",
+    leagueId,
+    userId,
+    role: "member",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  vi.mocked(getLeagueById).mockResolvedValue(straightUpLeague);
+  vi.mocked(getPhaseById).mockResolvedValue(openPhase);
+  vi.mocked(getSeasonsBySportsLeague).mockResolvedValue([currentSeason]);
+  vi.mocked(getAppNow).mockResolvedValue(nowBeforeLock);
+  vi.mocked(getOddsForEventsWithSportsbook).mockResolvedValue([]);
+  vi.mocked(deleteUserPicksForEvents).mockResolvedValue(undefined);
+  vi.mocked(insertPicks).mockResolvedValue([]);
+});
+
+describe("submitPicksAction", () => {
+  it("rejects invalid input before touching the DB", async () => {
+    const result = await submitPicksAction({ junk: true });
+    expect(result).toEqual({
+      success: false,
+      error: expect.any(String),
+    });
+    expect(insertPicks).not.toHaveBeenCalled();
+  });
+
+  it("propagates ForbiddenError when the user is not a member", async () => {
+    vi.mocked(assertLeagueMember).mockRejectedValueOnce(
+      new ForbiddenError("Not a league member"),
+    );
+    await expect(
+      submitPicksAction({
+        leagueId,
+        phaseId,
+        picks: [{ eventId: eventAId, teamId: homeTeamId }],
+      }),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+  });
+
+  it("returns 'League not found' when league is missing", async () => {
+    vi.mocked(getLeagueById).mockResolvedValueOnce(null);
+    const result = await submitPicksAction({
+      leagueId,
+      phaseId,
+      picks: [{ eventId: eventAId, teamId: homeTeamId }],
+    });
+    expect(result).toEqual({ success: false, error: "League not found." });
+  });
+
+  it("rejects a phase that isn't in the league's range", async () => {
+    vi.mocked(getPhaseById).mockResolvedValueOnce({
+      ...openPhase,
+      seasonType: "postseason",
+      weekNumber: 1,
+    });
+    const result = await submitPicksAction({
+      leagueId,
+      phaseId,
+      picks: [{ eventId: eventAId, teamId: homeTeamId }],
+    });
+    expect(result.success).toBe(false);
+    expect(result).toMatchObject({
+      error: expect.stringContaining("isn't part of this league"),
+    });
+  });
+
+  it("rejects a phase whose seasonId doesn't match the current season", async () => {
+    vi.mocked(getPhaseById).mockResolvedValueOnce({
+      ...openPhase,
+      seasonId: "99999999-9999-4999-8999-999999999999",
+    });
+    const result = await submitPicksAction({
+      leagueId,
+      phaseId,
+      picks: [{ eventId: eventAId, teamId: homeTeamId }],
+    });
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("isn't in the current season"),
+    });
+    expect(insertPicks).not.toHaveBeenCalled();
+  });
+
+  it("rejects submission after the phase's pick lock", async () => {
+    vi.mocked(getAppNow).mockResolvedValueOnce(
+      new Date("2099-09-21T17:00:00Z"),
+    );
+    const result = await submitPicksAction({
+      leagueId,
+      phaseId,
+      picks: [{ eventId: eventAId, teamId: homeTeamId }],
+    });
+    expect(result).toEqual({
+      success: false,
+      error: "Picks have locked for this phase.",
+    });
+  });
+
+  it("requires exactly min(picksPerPhase, unstartedGames) picks", async () => {
+    // 3 unstarted games, picksPerPhase=2 → required = 2
+    vi.mocked(getEventsByPhaseWithTeams).mockResolvedValue([
+      makeEvent(eventAId, new Date("2099-09-21T16:00:00Z")),
+      makeEvent(eventBId, new Date("2099-09-21T16:00:00Z")),
+      makeEvent(eventCId, new Date("2099-09-21T16:00:00Z")),
+    ]);
+
+    const tooFew = await submitPicksAction({
+      leagueId,
+      phaseId,
+      picks: [{ eventId: eventAId, teamId: homeTeamId }],
+    });
+    expect(tooFew).toMatchObject({
+      success: false,
+      error: expect.stringContaining("exactly 2"),
+    });
+
+    const tooMany = await submitPicksAction({
+      leagueId,
+      phaseId,
+      picks: [
+        { eventId: eventAId, teamId: homeTeamId },
+        { eventId: eventBId, teamId: homeTeamId },
+        { eventId: eventCId, teamId: homeTeamId },
+      ],
+    });
+    expect(tooMany).toMatchObject({
+      success: false,
+      error: expect.stringContaining("exactly 2"),
+    });
+  });
+
+  it("clamps required count to unstarted games when fewer than picksPerPhase remain", async () => {
+    // 2 unstarted + 1 started (locked) → required = min(2, 2) = 2
+    vi.mocked(getEventsByPhaseWithTeams).mockResolvedValue([
+      makeEvent(eventAId, new Date("2099-09-21T16:00:00Z")), // unstarted
+      makeEvent(eventBId, new Date("2099-09-21T16:00:00Z")), // unstarted
+      makeEvent(eventCId, new Date("2099-09-20T00:00:00Z")), // started before now
+    ]);
+
+    const result = await submitPicksAction({
+      leagueId,
+      phaseId,
+      picks: [
+        { eventId: eventAId, teamId: homeTeamId },
+        { eventId: eventBId, teamId: homeTeamId },
+      ],
+    });
+    expect(result).toEqual({ success: true, data: undefined });
+    expect(insertPicks).toHaveBeenCalledTimes(1);
+    expect(insertPicks).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({ eventId: eventAId, teamId: homeTeamId }),
+        expect.objectContaining({ eventId: eventBId, teamId: homeTeamId }),
+      ],
+      {},
+    );
+  });
+
+  it("rejects a pick on a game that has already started", async () => {
+    vi.mocked(getEventsByPhaseWithTeams).mockResolvedValue([
+      makeEvent(eventAId, new Date("2099-09-20T00:00:00Z")), // started
+      makeEvent(eventBId, new Date("2099-09-21T16:00:00Z")),
+    ]);
+    // With 1 unstarted event, required count = 1. Picking a started game
+    // should fail at the event-status check.
+    const result = await submitPicksAction({
+      leagueId,
+      phaseId,
+      picks: [{ eventId: eventAId, teamId: homeTeamId }],
+    });
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("already started"),
+    });
+  });
+
+  it("rejects duplicate game picks in a single submission", async () => {
+    vi.mocked(getEventsByPhaseWithTeams).mockResolvedValue([
+      makeEvent(eventAId, new Date("2099-09-21T16:00:00Z")),
+      makeEvent(eventBId, new Date("2099-09-21T16:00:00Z")),
+    ]);
+    const result = await submitPicksAction({
+      leagueId,
+      phaseId,
+      picks: [
+        { eventId: eventAId, teamId: homeTeamId },
+        { eventId: eventAId, teamId: awayTeamId },
+      ],
+    });
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("only be picked once"),
+    });
+  });
+
+  it("rejects a pick whose team isn't in the game", async () => {
+    vi.mocked(getEventsByPhaseWithTeams).mockResolvedValue([
+      makeEvent(eventAId, new Date("2099-09-21T16:00:00Z")),
+      makeEvent(eventBId, new Date("2099-09-21T16:00:00Z")),
+    ]);
+    const result = await submitPicksAction({
+      leagueId,
+      phaseId,
+      picks: [
+        { eventId: eventAId, teamId: homeTeamId },
+        { eventId: eventBId, teamId: "99999999-9999-4999-8999-999999999999" },
+      ],
+    });
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("isn't in that game"),
+    });
+  });
+
+  it("deletes existing picks on unstarted events and inserts new ones in a transaction", async () => {
+    vi.mocked(getEventsByPhaseWithTeams).mockResolvedValue([
+      makeEvent(eventAId, new Date("2099-09-21T16:00:00Z")),
+      makeEvent(eventBId, new Date("2099-09-21T16:00:00Z")),
+    ]);
+
+    const result = await submitPicksAction({
+      leagueId,
+      phaseId,
+      picks: [
+        { eventId: eventAId, teamId: homeTeamId },
+        { eventId: eventBId, teamId: awayTeamId },
+      ],
+    });
+
+    expect(result).toEqual({ success: true, data: undefined });
+    expect(deleteUserPicksForEvents).toHaveBeenCalledWith(
+      leagueId,
+      userId,
+      [eventAId, eventBId],
+      {},
+    );
+    expect(insertPicks).toHaveBeenCalledTimes(1);
+    expect(insertPicks).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          leagueId,
+          userId,
+          phaseId,
+          eventId: eventAId,
+          teamId: homeTeamId,
+          spreadAtLock: null,
+        }),
+        expect.objectContaining({
+          leagueId,
+          userId,
+          phaseId,
+          eventId: eventBId,
+          teamId: awayTeamId,
+          spreadAtLock: null,
+        }),
+      ],
+      {},
+    );
+  });
+
+  it("freezes the picked team's spread on ATS leagues", async () => {
+    vi.mocked(getLeagueById).mockResolvedValueOnce(atsLeague);
+    vi.mocked(getEventsByPhaseWithTeams).mockResolvedValue([
+      makeEvent(eventAId, new Date("2099-09-21T16:00:00Z")),
+    ]);
+    vi.mocked(getOddsForEventsWithSportsbook).mockResolvedValueOnce([
+      {
+        id: "odds-1",
+        eventId: eventAId,
+        sportsbookId: "sb-1",
+        sportsbookName: "ESPN Bet",
+        homeSpread: -3.5,
+        awaySpread: 3.5,
+        homeMoneyline: -150,
+        awayMoneyline: 130,
+        overUnder: 45.5,
+        lockedAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+
+    const result = await submitPicksAction({
+      leagueId,
+      phaseId,
+      picks: [{ eventId: eventAId, teamId: awayTeamId }],
+    });
+
+    expect(result).toEqual({ success: true, data: undefined });
+    expect(insertPicks).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          eventId: eventAId,
+          teamId: awayTeamId,
+          spreadAtLock: 3.5,
+        }),
+      ],
+      {},
+    );
+  });
+
+  it("rejects ATS submission when spreads aren't synced yet", async () => {
+    vi.mocked(getLeagueById).mockResolvedValueOnce(atsLeague);
+    vi.mocked(getEventsByPhaseWithTeams).mockResolvedValue([
+      makeEvent(eventAId, new Date("2099-09-21T16:00:00Z")),
+    ]);
+    // No odds rows returned
+    vi.mocked(getOddsForEventsWithSportsbook).mockResolvedValueOnce([]);
+
+    const result = await submitPicksAction({
+      leagueId,
+      phaseId,
+      picks: [{ eventId: eventAId, teamId: homeTeamId }],
+    });
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("Spreads aren't available"),
+    });
+    expect(insertPicks).not.toHaveBeenCalled();
+  });
+
+  it("preserves picks on already-started games when re-submitting (§7.2)", async () => {
+    // 2 started + 2 unstarted. required = min(picksPerPhase=2, unstarted=2) = 2.
+    // The delete only targets unstarted event ids; started-event picks stay.
+    vi.mocked(getEventsByPhaseWithTeams).mockResolvedValue([
+      makeEvent(eventAId, new Date("2099-09-20T00:00:00Z")), // started
+      makeEvent(eventBId, new Date("2099-09-20T00:00:00Z")), // started
+      makeEvent(eventCId, new Date("2099-09-21T16:00:00Z")), // unstarted
+      makeEvent(
+        "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        new Date("2099-09-21T16:00:00Z"),
+      ),
+    ]);
+
+    const result = await submitPicksAction({
+      leagueId,
+      phaseId,
+      picks: [
+        { eventId: eventCId, teamId: homeTeamId },
+        {
+          eventId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          teamId: homeTeamId,
+        },
+      ],
+    });
+
+    expect(result).toEqual({ success: true, data: undefined });
+    // The delete scope excludes eventAId/eventBId (started), so their picks
+    // survive the re-submit — this is the §7.2 guarantee.
+    expect(deleteUserPicksForEvents).toHaveBeenCalledWith(
+      leagueId,
+      userId,
+      [eventCId, "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"],
+      {},
+    );
+  });
+
+  it("re-submitting an ATS pick refreshes spreadAtLock from the current odds (§9.3)", async () => {
+    vi.mocked(getLeagueById).mockResolvedValue(atsLeague);
+    vi.mocked(getEventsByPhaseWithTeams).mockResolvedValue([
+      makeEvent(eventAId, new Date("2099-09-21T16:00:00Z")),
+    ]);
+    // Simulate a line move between submissions: first -3.5, then -7.
+    vi.mocked(getOddsForEventsWithSportsbook)
+      .mockResolvedValueOnce([
+        {
+          id: "odds-1",
+          eventId: eventAId,
+          sportsbookId: "sb-1",
+          sportsbookName: "ESPN Bet",
+          homeSpread: -3.5,
+          awaySpread: 3.5,
+          homeMoneyline: -150,
+          awayMoneyline: 130,
+          overUnder: 45.5,
+          lockedAt: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: "odds-1",
+          eventId: eventAId,
+          sportsbookId: "sb-1",
+          sportsbookName: "ESPN Bet",
+          homeSpread: -7,
+          awaySpread: 7,
+          homeMoneyline: -250,
+          awayMoneyline: 210,
+          overUnder: 46,
+          lockedAt: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+
+    const first = await submitPicksAction({
+      leagueId,
+      phaseId,
+      picks: [{ eventId: eventAId, teamId: homeTeamId }],
+    });
+    expect(first).toEqual({ success: true, data: undefined });
+    expect(insertPicks).toHaveBeenNthCalledWith(
+      1,
+      [expect.objectContaining({ spreadAtLock: -3.5 })],
+      {},
+    );
+
+    const second = await submitPicksAction({
+      leagueId,
+      phaseId,
+      picks: [{ eventId: eventAId, teamId: homeTeamId }],
+    });
+    expect(second).toEqual({ success: true, data: undefined });
+    expect(insertPicks).toHaveBeenNthCalledWith(
+      2,
+      [expect.objectContaining({ spreadAtLock: -7 })],
+      {},
+    );
+  });
+
+  it("returns an error when there are no unstarted games left", async () => {
+    vi.mocked(getEventsByPhaseWithTeams).mockResolvedValue([
+      makeEvent(eventAId, new Date("2099-09-20T00:00:00Z")),
+    ]);
+
+    const result = await submitPicksAction({
+      leagueId,
+      phaseId,
+      picks: [{ eventId: eventAId, teamId: homeTeamId }],
+    });
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("No games left"),
+    });
+  });
+});

--- a/actions/picks.ts
+++ b/actions/picks.ts
@@ -5,7 +5,7 @@ import { revalidatePath } from "next/cache";
 import {
   getEventsByPhaseWithTeams,
   getOddsForEventsWithSportsbook,
-  type OddsWithSportsbookName,
+  indexPrimaryOddsByEvent,
 } from "@/data/events";
 import { getLeagueById } from "@/data/leagues";
 import { getPhaseById } from "@/data/phases";
@@ -123,15 +123,9 @@ export async function submitPicksAction(input: unknown): Promise<ActionResult> {
   // pick is scored against what the user saw — §9.3.
   const frozenSpreadByEventId = new Map<string, number>();
   if (league.pickType === "against_the_spread") {
-    const oddsByEventId = new Map<string, OddsWithSportsbookName>();
-    const rows = await getOddsForEventsWithSportsbook(
-      selections.map((s) => s.eventId),
+    const oddsByEventId = indexPrimaryOddsByEvent(
+      await getOddsForEventsWithSportsbook(selections.map((s) => s.eventId)),
     );
-    for (const row of rows) {
-      if (!oddsByEventId.has(row.eventId)) {
-        oddsByEventId.set(row.eventId, row);
-      }
-    }
     for (const sel of selections) {
       const odds = oddsByEventId.get(sel.eventId);
       const event = eventsById.get(sel.eventId);

--- a/actions/picks.ts
+++ b/actions/picks.ts
@@ -8,16 +8,22 @@ import {
   indexPrimaryOddsByEvent,
 } from "@/data/events";
 import { getLeagueById } from "@/data/leagues";
-import { getPhaseById } from "@/data/phases";
-import { deleteUserPicksForEvents, insertPicks } from "@/data/picks";
+import { getPhasesBySeason } from "@/data/phases";
+import {
+  deleteUserPicksForEvents,
+  getPicksForLeaguePhase,
+  insertPicks,
+} from "@/data/picks";
 import { getSeasonsBySportsLeague } from "@/data/seasons";
 import { withTransaction } from "@/data/utils";
 import { getSession } from "@/lib/auth";
 import type { NewPick } from "@/lib/db/schema/picks";
 import {
+  hasEventStarted,
   isPhaseInLeagueRange,
   isPhaseLocked,
   selectCurrentSeason,
+  selectLeagueCurrentPhase,
 } from "@/lib/nfl/leagues";
 import { assertLeagueMember } from "@/lib/permissions";
 import { getAppNow } from "@/lib/simulator";
@@ -43,28 +49,30 @@ export async function submitPicksAction(input: unknown): Promise<ActionResult> {
     return { success: false, error: "League not found." };
   }
 
-  const phase = await getPhaseById(phaseId);
-  if (!phase) {
-    return { success: false, error: "Phase not found." };
+  const now = await getAppNow();
+
+  const seasons = await getSeasonsBySportsLeague(league.sportsLeagueId);
+  const currentSeason = selectCurrentSeason(seasons, now);
+  if (!currentSeason) {
+    return { success: false, error: "No active season for this league." };
   }
+
+  // §7.1 #2: picks can only be submitted for the current phase — the phase
+  // that §6.3 resolves given "now" and the league's range. Future and past
+  // phases in the range are view-only.
+  const seasonPhases = await getPhasesBySeason(currentSeason.id);
+  const currentPhase = selectLeagueCurrentPhase(seasonPhases, league, now);
+  if (!currentPhase || currentPhase.id !== phaseId) {
+    return {
+      success: false,
+      error: "You can only submit picks for the current week.",
+    };
+  }
+  const phase = currentPhase;
   if (!isPhaseInLeagueRange(phase, league)) {
     return {
       success: false,
       error: "That phase isn't part of this league's schedule.",
-    };
-  }
-
-  const now = await getAppNow();
-
-  // §7.1 #2: picks can only be submitted for the current phase. The phase
-  // must belong to the league's sport AND to the current season (not a
-  // prior year's "Week 3" whose tuple also matches the league's range).
-  const seasons = await getSeasonsBySportsLeague(league.sportsLeagueId);
-  const currentSeason = selectCurrentSeason(seasons, now);
-  if (!currentSeason || phase.seasonId !== currentSeason.id) {
-    return {
-      success: false,
-      error: "That phase isn't in the current season.",
     };
   }
 
@@ -74,13 +82,32 @@ export async function submitPicksAction(input: unknown): Promise<ActionResult> {
 
   const events = await getEventsByPhaseWithTeams(phase.id);
   const eventsById = new Map(events.map((e) => [e.id, e]));
-  const unstartedEvents = events.filter((e) => now < e.startTime);
-  const requiredCount = Math.min(league.picksPerPhase, unstartedEvents.length);
+  const unstartedEvents = events.filter((e) => !hasEventStarted(e, now));
+  const unstartedEventIds = new Set(unstartedEvents.map((e) => e.id));
+
+  // §7.1 #4: picks already locked in on started games consume the
+  // league's picksPerPhase budget. Required count for THIS submission is
+  // the remaining quota, clamped to the unstarted pool.
+  const existingPicks = await getPicksForLeaguePhase(
+    leagueId,
+    session.user.id,
+    phase.id,
+  );
+  const lockedPickCount = existingPicks.filter(
+    (p) => !unstartedEventIds.has(p.eventId),
+  ).length;
+  const requiredCount = Math.min(
+    Math.max(league.picksPerPhase - lockedPickCount, 0),
+    unstartedEvents.length,
+  );
 
   if (requiredCount === 0) {
     return {
       success: false,
-      error: "No games left to pick for this phase.",
+      error:
+        lockedPickCount >= league.picksPerPhase
+          ? "You've already locked in all your picks for this phase."
+          : "No games left to pick for this phase.",
     };
   }
 
@@ -105,7 +132,7 @@ export async function submitPicksAction(input: unknown): Promise<ActionResult> {
         error: "Pick references a game that isn't in this phase.",
       };
     }
-    if (now >= event.startTime) {
+    if (hasEventStarted(event, now)) {
       return {
         success: false,
         error: "Can't pick a game that has already started.",
@@ -120,7 +147,11 @@ export async function submitPicksAction(input: unknown): Promise<ActionResult> {
   }
 
   // For ATS leagues, freeze the current spread at submission time so the
-  // pick is scored against what the user saw — §9.3.
+  // pick is scored against what the user saw — §9.3. The client sends an
+  // `expectedSpread` per pick (the line it displayed when the user hit
+  // submit); if that doesn't match the server's current spread, we bail
+  // with STALE_ODDS so the client can refresh and show the moved line
+  // before the user commits.
   const frozenSpreadByEventId = new Map<string, number>();
   if (league.pickType === "against_the_spread") {
     const oddsByEventId = indexPrimaryOddsByEvent(
@@ -136,23 +167,30 @@ export async function submitPicksAction(input: unknown): Promise<ActionResult> {
             "Spreads aren't available yet for one of the games. Try again in a moment.",
         };
       }
-      const spread =
+      const serverSpread =
         sel.teamId === event.homeTeamId ? odds.homeSpread : odds.awaySpread;
-      if (spread == null) {
+      if (serverSpread == null) {
         return {
           success: false,
           error:
             "Spreads aren't available yet for one of the games. Try again in a moment.",
         };
       }
-      frozenSpreadByEventId.set(sel.eventId, spread);
+      if (sel.expectedSpread == null || sel.expectedSpread !== serverSpread) {
+        return {
+          success: false,
+          error:
+            "Lines moved while you were submitting — odds refreshed. Please review before re-submitting.",
+          code: "STALE_ODDS",
+        };
+      }
+      frozenSpreadByEventId.set(sel.eventId, serverSpread);
     }
   }
 
   // Replace the user's picks on unstarted events for this phase. Picks on
   // games that have already started are preserved automatically — they
   // aren't in `unstartedEvents`, so the delete leaves them untouched.
-  const unstartedEventIds = unstartedEvents.map((e) => e.id);
   const picksToInsert: Omit<NewPick, "id" | "createdAt" | "updatedAt">[] =
     selections.map((sel) => ({
       leagueId,
@@ -166,7 +204,7 @@ export async function submitPicksAction(input: unknown): Promise<ActionResult> {
     await deleteUserPicksForEvents(
       leagueId,
       session.user.id,
-      unstartedEventIds,
+      Array.from(unstartedEventIds),
       tx,
     );
     await insertPicks(picksToInsert, tx);

--- a/actions/picks.ts
+++ b/actions/picks.ts
@@ -1,0 +1,184 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import {
+  getEventsByPhaseWithTeams,
+  getOddsForEventsWithSportsbook,
+  type OddsWithSportsbookName,
+} from "@/data/events";
+import { getLeagueById } from "@/data/leagues";
+import { getPhaseById } from "@/data/phases";
+import { deleteUserPicksForEvents, insertPicks } from "@/data/picks";
+import { getSeasonsBySportsLeague } from "@/data/seasons";
+import { withTransaction } from "@/data/utils";
+import { getSession } from "@/lib/auth";
+import type { NewPick } from "@/lib/db/schema/picks";
+import {
+  isPhaseInLeagueRange,
+  isPhaseLocked,
+  selectCurrentSeason,
+} from "@/lib/nfl/leagues";
+import { assertLeagueMember } from "@/lib/permissions";
+import { getAppNow } from "@/lib/simulator";
+import type { ActionResult } from "@/lib/types";
+import { submitPicksSchema } from "@/lib/validators/picks";
+
+export async function submitPicksAction(input: unknown): Promise<ActionResult> {
+  const parsed = submitPicksSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: parsed.error.issues[0]?.message ?? "Invalid picks.",
+    };
+  }
+
+  const session = await getSession();
+  const { leagueId, phaseId, picks: selections } = parsed.data;
+
+  await assertLeagueMember(session.user.id, leagueId);
+
+  const league = await getLeagueById(leagueId);
+  if (!league) {
+    return { success: false, error: "League not found." };
+  }
+
+  const phase = await getPhaseById(phaseId);
+  if (!phase) {
+    return { success: false, error: "Phase not found." };
+  }
+  if (!isPhaseInLeagueRange(phase, league)) {
+    return {
+      success: false,
+      error: "That phase isn't part of this league's schedule.",
+    };
+  }
+
+  const now = await getAppNow();
+
+  // §7.1 #2: picks can only be submitted for the current phase. The phase
+  // must belong to the league's sport AND to the current season (not a
+  // prior year's "Week 3" whose tuple also matches the league's range).
+  const seasons = await getSeasonsBySportsLeague(league.sportsLeagueId);
+  const currentSeason = selectCurrentSeason(seasons, now);
+  if (!currentSeason || phase.seasonId !== currentSeason.id) {
+    return {
+      success: false,
+      error: "That phase isn't in the current season.",
+    };
+  }
+
+  if (isPhaseLocked(phase, now)) {
+    return { success: false, error: "Picks have locked for this phase." };
+  }
+
+  const events = await getEventsByPhaseWithTeams(phase.id);
+  const eventsById = new Map(events.map((e) => [e.id, e]));
+  const unstartedEvents = events.filter((e) => now < e.startTime);
+  const requiredCount = Math.min(league.picksPerPhase, unstartedEvents.length);
+
+  if (requiredCount === 0) {
+    return {
+      success: false,
+      error: "No games left to pick for this phase.",
+    };
+  }
+
+  if (selections.length !== requiredCount) {
+    return {
+      success: false,
+      error: `You must submit exactly ${requiredCount} pick${requiredCount === 1 ? "" : "s"}.`,
+    };
+  }
+
+  const seenEventIds = new Set<string>();
+  for (const sel of selections) {
+    if (seenEventIds.has(sel.eventId)) {
+      return { success: false, error: "Each game can only be picked once." };
+    }
+    seenEventIds.add(sel.eventId);
+
+    const event = eventsById.get(sel.eventId);
+    if (!event || event.phaseId !== phase.id) {
+      return {
+        success: false,
+        error: "Pick references a game that isn't in this phase.",
+      };
+    }
+    if (now >= event.startTime) {
+      return {
+        success: false,
+        error: "Can't pick a game that has already started.",
+      };
+    }
+    if (event.homeTeamId !== sel.teamId && event.awayTeamId !== sel.teamId) {
+      return {
+        success: false,
+        error: "Selected team isn't in that game.",
+      };
+    }
+  }
+
+  // For ATS leagues, freeze the current spread at submission time so the
+  // pick is scored against what the user saw — §9.3.
+  const frozenSpreadByEventId = new Map<string, number>();
+  if (league.pickType === "against_the_spread") {
+    const oddsByEventId = new Map<string, OddsWithSportsbookName>();
+    const rows = await getOddsForEventsWithSportsbook(
+      selections.map((s) => s.eventId),
+    );
+    for (const row of rows) {
+      if (!oddsByEventId.has(row.eventId)) {
+        oddsByEventId.set(row.eventId, row);
+      }
+    }
+    for (const sel of selections) {
+      const odds = oddsByEventId.get(sel.eventId);
+      const event = eventsById.get(sel.eventId);
+      if (!odds || !event) {
+        return {
+          success: false,
+          error:
+            "Spreads aren't available yet for one of the games. Try again in a moment.",
+        };
+      }
+      const spread =
+        sel.teamId === event.homeTeamId ? odds.homeSpread : odds.awaySpread;
+      if (spread == null) {
+        return {
+          success: false,
+          error:
+            "Spreads aren't available yet for one of the games. Try again in a moment.",
+        };
+      }
+      frozenSpreadByEventId.set(sel.eventId, spread);
+    }
+  }
+
+  // Replace the user's picks on unstarted events for this phase. Picks on
+  // games that have already started are preserved automatically — they
+  // aren't in `unstartedEvents`, so the delete leaves them untouched.
+  const unstartedEventIds = unstartedEvents.map((e) => e.id);
+  const picksToInsert: Omit<NewPick, "id" | "createdAt" | "updatedAt">[] =
+    selections.map((sel) => ({
+      leagueId,
+      userId: session.user.id,
+      phaseId: phase.id,
+      eventId: sel.eventId,
+      teamId: sel.teamId,
+      spreadAtLock: frozenSpreadByEventId.get(sel.eventId) ?? null,
+    }));
+  await withTransaction(async (tx) => {
+    await deleteUserPicksForEvents(
+      leagueId,
+      session.user.id,
+      unstartedEventIds,
+      tx,
+    );
+    await insertPicks(picksToInsert, tx);
+  });
+
+  revalidatePath(`/leagues/${leagueId}/my-picks`);
+  revalidatePath(`/leagues/${leagueId}/league-picks`);
+  return { success: true, data: undefined };
+}

--- a/app/(app)/leagues/[leagueId]/league-picks/page.tsx
+++ b/app/(app)/leagues/[leagueId]/league-picks/page.tsx
@@ -1,10 +1,170 @@
-import { ComingSoon } from "@/components/leagues/coming-soon";
+import { notFound } from "next/navigation";
 
-export default function LeaguePicksPage() {
+import { MemberPicksCard } from "@/components/picks/member-picks-card";
+import { PhaseNavigation } from "@/components/picks/phase-navigation";
+import { PickLockBanner } from "@/components/picks/pick-lock-banner";
+import {
+  getEventsByPhaseWithTeams,
+  getOddsForEventsWithSportsbook,
+  type OddsWithSportsbookName,
+} from "@/data/events";
+import { getLeagueById } from "@/data/leagues";
+import { getPhasesBySeason } from "@/data/phases";
+import { getPicksForLeaguePhaseAllMembers } from "@/data/picks";
+import { getSeasonsBySportsLeague } from "@/data/seasons";
+import { getStandingsForLeagueSeasonWithProfiles } from "@/data/standings";
+import { getSession } from "@/lib/auth";
+import type { League } from "@/lib/db/schema/leagues";
+import {
+  comparePhasesByOrdinal,
+  isPhaseInLeagueRange,
+  isPhaseLocked,
+  phaseLabel,
+  selectCurrentSeason,
+  selectLeagueCurrentPhase,
+} from "@/lib/nfl/leagues";
+import { getAppNow } from "@/lib/simulator";
+
+export default async function LeaguePicksPage(
+  props: PageProps<"/leagues/[leagueId]/league-picks">,
+) {
+  const { leagueId } = await props.params;
+  const searchParams = await props.searchParams;
+  const requestedPhaseId =
+    typeof searchParams.phase === "string" ? searchParams.phase : null;
+
+  const league = await getLeagueById(leagueId);
+  if (!league) notFound();
+
+  const now = await getAppNow();
+  const seasons = await getSeasonsBySportsLeague(league.sportsLeagueId);
+  const currentSeason = selectCurrentSeason(seasons, now);
+  if (!currentSeason) {
+    return <EmptyState message="No season data available yet." />;
+  }
+
+  const allPhases = await getPhasesBySeason(currentSeason.id);
+  const phasesInRange = allPhases
+    .filter((p) => isPhaseInLeagueRange(p, league))
+    .sort(comparePhasesByOrdinal);
+
+  const requestedPhase = requestedPhaseId
+    ? (phasesInRange.find((p) => p.id === requestedPhaseId) ?? null)
+    : null;
+  const selectedPhase =
+    requestedPhase ?? selectLeagueCurrentPhase(allPhases, league, now);
+
+  if (!selectedPhase) {
+    return (
+      <EmptyState message="This league's schedule range has no synced phases yet." />
+    );
+  }
+
+  const currentIndex = phasesInRange.findIndex(
+    (p) => p.id === selectedPhase.id,
+  );
+  const prevPhase = currentIndex > 0 ? phasesInRange[currentIndex - 1] : null;
+  const nextPhase =
+    currentIndex >= 0 && currentIndex < phasesInRange.length - 1
+      ? phasesInRange[currentIndex + 1]
+      : null;
+
+  const phaseLocked = isPhaseLocked(selectedPhase, now);
+
   return (
-    <ComingSoon
-      title="League Picks"
-      description="After the pick deadline you'll see every member's picks here."
-    />
+    <div className="flex flex-col gap-4">
+      <PhaseNavigation
+        basePath={`/leagues/${leagueId}/league-picks`}
+        currentPhase={selectedPhase}
+        prevPhase={prevPhase}
+        nextPhase={nextPhase}
+      />
+      <PickLockBanner
+        pickLockTime={selectedPhase.pickLockTime}
+        isLocked={phaseLocked}
+      />
+      {!phaseLocked ? (
+        <EmptyState
+          message={`League picks will be visible after the ${phaseLabel(
+            selectedPhase.seasonType,
+            selectedPhase.weekNumber,
+          )} deadline.`}
+        />
+      ) : (
+        <LockedPhaseContent
+          leagueId={leagueId}
+          league={league}
+          selectedPhaseId={selectedPhase.id}
+          currentSeasonId={currentSeason.id}
+        />
+      )}
+    </div>
+  );
+}
+
+async function LockedPhaseContent({
+  leagueId,
+  league,
+  selectedPhaseId,
+  currentSeasonId,
+}: {
+  leagueId: string;
+  league: Pick<League, "pickType">;
+  selectedPhaseId: string;
+  currentSeasonId: string;
+}) {
+  const session = await getSession();
+  const viewerUserId = session.user.id;
+  const events = await getEventsByPhaseWithTeams(selectedPhaseId);
+  const [picks, standings, oddsRows] = await Promise.all([
+    getPicksForLeaguePhaseAllMembers(leagueId, selectedPhaseId),
+    getStandingsForLeagueSeasonWithProfiles(leagueId, currentSeasonId),
+    getOddsForEventsWithSportsbook(events.map((e) => e.id)),
+  ]);
+
+  const oddsByEventId = new Map<string, OddsWithSportsbookName>();
+  for (const row of oddsRows) {
+    if (!oddsByEventId.has(row.eventId)) {
+      oddsByEventId.set(row.eventId, row);
+    }
+  }
+
+  const picksByUserId = new Map<string, typeof picks>();
+  for (const pick of picks) {
+    const existing = picksByUserId.get(pick.userId) ?? [];
+    existing.push(pick);
+    picksByUserId.set(pick.userId, existing);
+  }
+
+  if (standings.length === 0) {
+    return (
+      <EmptyState message="No members have standings yet for this season." />
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-2">
+      {standings.map((standing) => (
+        <li key={standing.id}>
+          <MemberPicksCard
+            standing={standing}
+            picks={picksByUserId.get(standing.userId) ?? []}
+            events={events}
+            oddsByEventId={oddsByEventId}
+            pickType={league.pickType}
+            isViewer={standing.userId === viewerUserId}
+            defaultOpen={standing.userId === viewerUserId}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <section className="rounded-lg border border-dashed p-8 text-center">
+      <p className="text-sm text-muted-foreground">{message}</p>
+    </section>
   );
 }

--- a/app/(app)/leagues/[leagueId]/league-picks/page.tsx
+++ b/app/(app)/leagues/[leagueId]/league-picks/page.tsx
@@ -21,6 +21,7 @@ import {
   resolvePhaseView,
   selectCurrentSeason,
 } from "@/lib/nfl/leagues";
+import { calculateWeeklyStandings } from "@/lib/nfl/scoring";
 import { getAppNow } from "@/lib/simulator";
 
 export default async function LeaguePicksPage(
@@ -67,6 +68,7 @@ export default async function LeaguePicksPage(
       />
       <PickLockBanner
         pickLockTime={selectedPhase.pickLockTime}
+        phaseStartDate={selectedPhase.startDate}
         isLocked={phaseLocked}
       />
       {!phaseLocked ? (
@@ -123,12 +125,36 @@ async function LockedPhaseContent({
     );
   }
 
+  // Compute per-member weekly standings and re-sort members by weekly
+  // points (desc) with overall points as tiebreaker — the league picks
+  // view is "who's doing best THIS week," with season-long standings
+  // breaking ties. Mirrors My Picks: the weekly column is only meaningful
+  // once at least one pick this phase is scored; until then fall back to
+  // the overall standings order and hide the weekly cell on cards.
+  const hasAnyScoredThisPhase = picks.some((p) => p.pickResult != null);
+  const weeklyStandings = hasAnyScoredThisPhase
+    ? calculateWeeklyStandings(
+        picks,
+        standings.map((s) => s.userId),
+      )
+    : [];
+  const weeklyByUserId = new Map(weeklyStandings.map((w) => [w.userId, w]));
+  const sortedStandings = hasAnyScoredThisPhase
+    ? [...standings].sort((a, b) => {
+        const wa = weeklyByUserId.get(a.userId)?.points ?? 0;
+        const wb = weeklyByUserId.get(b.userId)?.points ?? 0;
+        if (wa !== wb) return wb - wa;
+        return b.points - a.points;
+      })
+    : standings;
+
   return (
     <ul className="flex flex-col gap-2">
-      {standings.map((standing) => (
+      {sortedStandings.map((standing) => (
         <li key={standing.id}>
           <MemberPicksCard
             standing={standing}
+            weekly={weeklyByUserId.get(standing.userId) ?? null}
             picks={picksByUserId.get(standing.userId) ?? []}
             events={events}
             oddsByEventId={oddsByEventId}

--- a/app/(app)/leagues/[leagueId]/league-picks/page.tsx
+++ b/app/(app)/leagues/[leagueId]/league-picks/page.tsx
@@ -6,7 +6,7 @@ import { PickLockBanner } from "@/components/picks/pick-lock-banner";
 import {
   getEventsByPhaseWithTeams,
   getOddsForEventsWithSportsbook,
-  type OddsWithSportsbookName,
+  indexPrimaryOddsByEvent,
 } from "@/data/events";
 import { getLeagueById } from "@/data/leagues";
 import { getPhasesBySeason } from "@/data/phases";
@@ -16,12 +16,10 @@ import { getStandingsForLeagueSeasonWithProfiles } from "@/data/standings";
 import { getSession } from "@/lib/auth";
 import type { League } from "@/lib/db/schema/leagues";
 import {
-  comparePhasesByOrdinal,
-  isPhaseInLeagueRange,
   isPhaseLocked,
   phaseLabel,
+  resolvePhaseView,
   selectCurrentSeason,
-  selectLeagueCurrentPhase,
 } from "@/lib/nfl/leagues";
 import { getAppNow } from "@/lib/simulator";
 
@@ -44,30 +42,18 @@ export default async function LeaguePicksPage(
   }
 
   const allPhases = await getPhasesBySeason(currentSeason.id);
-  const phasesInRange = allPhases
-    .filter((p) => isPhaseInLeagueRange(p, league))
-    .sort(comparePhasesByOrdinal);
-
-  const requestedPhase = requestedPhaseId
-    ? (phasesInRange.find((p) => p.id === requestedPhaseId) ?? null)
-    : null;
-  const selectedPhase =
-    requestedPhase ?? selectLeagueCurrentPhase(allPhases, league, now);
-
-  if (!selectedPhase) {
+  const resolved = resolvePhaseView({
+    league,
+    allPhases,
+    requestedPhaseId,
+    now,
+  });
+  if (resolved.kind === "no-phases-in-range") {
     return (
       <EmptyState message="This league's schedule range has no synced phases yet." />
     );
   }
-
-  const currentIndex = phasesInRange.findIndex(
-    (p) => p.id === selectedPhase.id,
-  );
-  const prevPhase = currentIndex > 0 ? phasesInRange[currentIndex - 1] : null;
-  const nextPhase =
-    currentIndex >= 0 && currentIndex < phasesInRange.length - 1
-      ? phasesInRange[currentIndex + 1]
-      : null;
+  const { selectedPhase, prevPhase, nextPhase } = resolved;
 
   const phaseLocked = isPhaseLocked(selectedPhase, now);
 
@@ -122,12 +108,7 @@ async function LockedPhaseContent({
     getOddsForEventsWithSportsbook(events.map((e) => e.id)),
   ]);
 
-  const oddsByEventId = new Map<string, OddsWithSportsbookName>();
-  for (const row of oddsRows) {
-    if (!oddsByEventId.has(row.eventId)) {
-      oddsByEventId.set(row.eventId, row);
-    }
-  }
+  const oddsByEventId = indexPrimaryOddsByEvent(oddsRows);
 
   const picksByUserId = new Map<string, typeof picks>();
   for (const pick of picks) {

--- a/app/(app)/leagues/[leagueId]/my-picks/page.tsx
+++ b/app/(app)/leagues/[leagueId]/my-picks/page.tsx
@@ -8,7 +8,7 @@ import { SubmitPicksForm } from "@/components/picks/submit-picks-form";
 import {
   getEventsByPhaseWithTeams,
   getOddsForEventsWithSportsbook,
-  type OddsWithSportsbookName,
+  indexPrimaryOddsByEvent,
 } from "@/data/events";
 import { getLeagueById, getLeagueMemberCount } from "@/data/leagues";
 import { getPhasesBySeason } from "@/data/phases";
@@ -17,13 +17,11 @@ import { getSeasonsBySportsLeague } from "@/data/seasons";
 import { getLeagueStanding } from "@/data/standings";
 import { getSession } from "@/lib/auth";
 import {
-  comparePhasesByOrdinal,
-  isPhaseInLeagueRange,
   isPhaseLocked,
   isPickLocked,
   phaseLabel,
+  resolvePhaseView,
   selectCurrentSeason,
-  selectLeagueCurrentPhase,
 } from "@/lib/nfl/leagues";
 import { getAppNow } from "@/lib/simulator";
 
@@ -52,30 +50,18 @@ export default async function MyPicksPage(
   }
 
   const allPhases = await getPhasesBySeason(currentSeason.id);
-  const phasesInRange = allPhases
-    .filter((p) => isPhaseInLeagueRange(p, league))
-    .sort(comparePhasesByOrdinal);
-
-  const requestedPhase = requestedPhaseId
-    ? (phasesInRange.find((p) => p.id === requestedPhaseId) ?? null)
-    : null;
-  const selectedPhase =
-    requestedPhase ?? selectLeagueCurrentPhase(allPhases, league, now);
-
-  if (!selectedPhase) {
+  const resolved = resolvePhaseView({
+    league,
+    allPhases,
+    requestedPhaseId,
+    now,
+  });
+  if (resolved.kind === "no-phases-in-range") {
     return (
       <EmptyState message="This league's schedule range has no synced phases yet." />
     );
   }
-
-  const currentIndex = phasesInRange.findIndex(
-    (p) => p.id === selectedPhase.id,
-  );
-  const prevPhase = currentIndex > 0 ? phasesInRange[currentIndex - 1] : null;
-  const nextPhase =
-    currentIndex >= 0 && currentIndex < phasesInRange.length - 1
-      ? phasesInRange[currentIndex + 1]
-      : null;
+  const { selectedPhase, prevPhase, nextPhase } = resolved;
 
   const events = await getEventsByPhaseWithTeams(selectedPhase.id);
   const [standing, picks, oddsRows] = await Promise.all([
@@ -83,15 +69,7 @@ export default async function MyPicksPage(
     getPicksForLeaguePhase(leagueId, session.user.id, selectedPhase.id),
     getOddsForEventsWithSportsbook(events.map((e) => e.id)),
   ]);
-  // Deterministic dedupe: data layer orders by sportsbook name ascending,
-  // so the first row we see per event is the one we keep. When multiple
-  // sportsbooks get seeded this becomes the place to decide priority.
-  const oddsByEventId = new Map<string, OddsWithSportsbookName>();
-  for (const row of oddsRows) {
-    if (!oddsByEventId.has(row.eventId)) {
-      oddsByEventId.set(row.eventId, row);
-    }
-  }
+  const oddsByEventId = indexPrimaryOddsByEvent(oddsRows);
   const pickByEventId = new Map(picks.map((p) => [p.eventId, p]));
   const phaseLocked = isPhaseLocked(selectedPhase, now);
 

--- a/app/(app)/leagues/[leagueId]/my-picks/page.tsx
+++ b/app/(app)/leagues/[leagueId]/my-picks/page.tsx
@@ -1,10 +1,145 @@
-import { ComingSoon } from "@/components/leagues/coming-soon";
+import { notFound } from "next/navigation";
 
-export default function MyPicksPage() {
+import { EventPickCard } from "@/components/picks/event-pick-card";
+import { MyPicksHeader } from "@/components/picks/my-picks-header";
+import { PhaseNavigation } from "@/components/picks/phase-navigation";
+import { PickLockBanner } from "@/components/picks/pick-lock-banner";
+import {
+  getEventsByPhaseWithTeams,
+  getOddsForEventsWithSportsbook,
+  type OddsWithSportsbookName,
+} from "@/data/events";
+import { getLeagueById, getLeagueMemberCount } from "@/data/leagues";
+import { getPhasesBySeason } from "@/data/phases";
+import { getPicksForLeaguePhase } from "@/data/picks";
+import { getSeasonsBySportsLeague } from "@/data/seasons";
+import { getLeagueStanding } from "@/data/standings";
+import { getSession } from "@/lib/auth";
+import {
+  comparePhasesByOrdinal,
+  isPhaseInLeagueRange,
+  isPhaseLocked,
+  isPickLocked,
+  phaseLabel,
+  selectCurrentSeason,
+  selectLeagueCurrentPhase,
+} from "@/lib/nfl/leagues";
+import { getAppNow } from "@/lib/simulator";
+
+export default async function MyPicksPage(
+  props: PageProps<"/leagues/[leagueId]/my-picks">,
+) {
+  const { leagueId } = await props.params;
+  const searchParams = await props.searchParams;
+  const phaseIdParam = searchParams.phase;
+  const requestedPhaseId =
+    typeof phaseIdParam === "string" ? phaseIdParam : null;
+
+  const session = await getSession();
+  const league = await getLeagueById(leagueId);
+  if (!league) notFound();
+
+  const now = await getAppNow();
+  const [memberCount, seasons] = await Promise.all([
+    getLeagueMemberCount(leagueId),
+    getSeasonsBySportsLeague(league.sportsLeagueId),
+  ]);
+  const currentSeason = selectCurrentSeason(seasons, now);
+
+  if (!currentSeason) {
+    return <EmptyState message="No season data available yet." />;
+  }
+
+  const allPhases = await getPhasesBySeason(currentSeason.id);
+  const phasesInRange = allPhases
+    .filter((p) => isPhaseInLeagueRange(p, league))
+    .sort(comparePhasesByOrdinal);
+
+  const requestedPhase = requestedPhaseId
+    ? (phasesInRange.find((p) => p.id === requestedPhaseId) ?? null)
+    : null;
+  const selectedPhase =
+    requestedPhase ?? selectLeagueCurrentPhase(allPhases, league, now);
+
+  if (!selectedPhase) {
+    return (
+      <EmptyState message="This league's schedule range has no synced phases yet." />
+    );
+  }
+
+  const currentIndex = phasesInRange.findIndex(
+    (p) => p.id === selectedPhase.id,
+  );
+  const prevPhase = currentIndex > 0 ? phasesInRange[currentIndex - 1] : null;
+  const nextPhase =
+    currentIndex >= 0 && currentIndex < phasesInRange.length - 1
+      ? phasesInRange[currentIndex + 1]
+      : null;
+
+  const events = await getEventsByPhaseWithTeams(selectedPhase.id);
+  const [standing, picks, oddsRows] = await Promise.all([
+    getLeagueStanding(leagueId, session.user.id, currentSeason.id),
+    getPicksForLeaguePhase(leagueId, session.user.id, selectedPhase.id),
+    getOddsForEventsWithSportsbook(events.map((e) => e.id)),
+  ]);
+  // Deterministic dedupe: data layer orders by sportsbook name ascending,
+  // so the first row we see per event is the one we keep. When multiple
+  // sportsbooks get seeded this becomes the place to decide priority.
+  const oddsByEventId = new Map<string, OddsWithSportsbookName>();
+  for (const row of oddsRows) {
+    if (!oddsByEventId.has(row.eventId)) {
+      oddsByEventId.set(row.eventId, row);
+    }
+  }
+  const pickByEventId = new Map(picks.map((p) => [p.eventId, p]));
+  const phaseLocked = isPhaseLocked(selectedPhase, now);
+
   return (
-    <ComingSoon
-      title="My Picks"
-      description="You'll make and edit your weekly picks here once the picks feature lands."
-    />
+    <div className="flex flex-col gap-4">
+      <MyPicksHeader standing={standing} memberCount={memberCount} />
+      <PhaseNavigation
+        basePath={`/leagues/${leagueId}/my-picks`}
+        currentPhase={selectedPhase}
+        prevPhase={prevPhase}
+        nextPhase={nextPhase}
+      />
+      <PickLockBanner
+        pickLockTime={selectedPhase.pickLockTime}
+        isLocked={phaseLocked}
+      />
+      {events.length === 0 ? (
+        <EmptyState
+          message={`No games scheduled for ${phaseLabel(selectedPhase.seasonType, selectedPhase.weekNumber)}.`}
+        />
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {events.map((event) => {
+            const pick = pickByEventId.get(event.id) ?? null;
+            const locked = isPickLocked(selectedPhase, event, now);
+            return (
+              <li key={event.id}>
+                <EventPickCard
+                  event={event}
+                  homeTeam={event.homeTeam}
+                  awayTeam={event.awayTeam}
+                  odds={oddsByEventId.get(event.id) ?? null}
+                  pickType={league.pickType}
+                  pick={pick}
+                  isLocked={locked}
+                />
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <section className="rounded-lg border border-dashed p-8 text-center">
+      <p className="text-sm text-muted-foreground">{message}</p>
+    </section>
   );
 }

--- a/app/(app)/leagues/[leagueId]/my-picks/page.tsx
+++ b/app/(app)/leagues/[leagueId]/my-picks/page.tsx
@@ -12,9 +12,15 @@ import {
 } from "@/data/events";
 import { getLeagueById, getLeagueMemberCount } from "@/data/leagues";
 import { getPhasesBySeason } from "@/data/phases";
-import { getPicksForLeaguePhase } from "@/data/picks";
+import {
+  getPicksForLeaguePhase,
+  getPicksForLeaguePhaseAllMembers,
+} from "@/data/picks";
 import { getSeasonsBySportsLeague } from "@/data/seasons";
-import { getLeagueStanding } from "@/data/standings";
+import {
+  getLeagueStanding,
+  getStandingsForLeagueSeasonWithProfiles,
+} from "@/data/standings";
 import { getSession } from "@/lib/auth";
 import {
   isPhaseLocked,
@@ -22,7 +28,9 @@ import {
   phaseLabel,
   resolvePhaseView,
   selectCurrentSeason,
+  selectLeagueCurrentPhase,
 } from "@/lib/nfl/leagues";
+import { calculateWeeklyStandings } from "@/lib/nfl/scoring";
 import { getAppNow } from "@/lib/simulator";
 
 export default async function MyPicksPage(
@@ -64,18 +72,45 @@ export default async function MyPicksPage(
   const { selectedPhase, prevPhase, nextPhase } = resolved;
 
   const events = await getEventsByPhaseWithTeams(selectedPhase.id);
-  const [standing, picks, oddsRows] = await Promise.all([
-    getLeagueStanding(leagueId, session.user.id, currentSeason.id),
-    getPicksForLeaguePhase(leagueId, session.user.id, selectedPhase.id),
-    getOddsForEventsWithSportsbook(events.map((e) => e.id)),
-  ]);
+  const [standing, picks, oddsRows, memberStandings, allPhasePicks] =
+    await Promise.all([
+      getLeagueStanding(leagueId, session.user.id, currentSeason.id),
+      getPicksForLeaguePhase(leagueId, session.user.id, selectedPhase.id),
+      getOddsForEventsWithSportsbook(events.map((e) => e.id)),
+      getStandingsForLeagueSeasonWithProfiles(leagueId, currentSeason.id),
+      getPicksForLeaguePhaseAllMembers(leagueId, selectedPhase.id),
+    ]);
   const oddsByEventId = indexPrimaryOddsByEvent(oddsRows);
   const pickByEventId = new Map(picks.map((p) => [p.eventId, p]));
   const phaseLocked = isPhaseLocked(selectedPhase, now);
+  const currentPhase = selectLeagueCurrentPhase(allPhases, league, now);
+  const isCurrentPhase = currentPhase?.id === selectedPhase.id;
+  const canSubmitPicks = !phaseLocked && isCurrentPhase;
+
+  // Weekly row is only meaningful once at least one pick this phase is
+  // scored. Before that everyone is 0-0-0 and the row is visual noise.
+  const hasAnyScoredThisPhase = allPhasePicks.some((p) => p.pickResult != null);
+  const viewerWeekly = hasAnyScoredThisPhase
+    ? (calculateWeeklyStandings(
+        allPhasePicks,
+        memberStandings.map((s) => s.userId),
+      ).find((w) => w.userId === session.user.id) ?? null)
+    : null;
+
+  // After lock, drop games the viewer didn't pick — they're noise on the
+  // "My Picks" surface. Future phases (pre-lock, not current) still show
+  // the full schedule so the user can preview upcoming games.
+  const eventsToShow = phaseLocked
+    ? events.filter((e) => pickByEventId.has(e.id))
+    : events;
 
   return (
     <div className="flex flex-col gap-4">
-      <MyPicksHeader standing={standing} memberCount={memberCount} />
+      <MyPicksHeader
+        standing={standing}
+        weekly={viewerWeekly}
+        memberCount={memberCount}
+      />
       <PhaseNavigation
         basePath={`/leagues/${leagueId}/my-picks`}
         currentPhase={selectedPhase}
@@ -84,36 +119,43 @@ export default async function MyPicksPage(
       />
       <PickLockBanner
         pickLockTime={selectedPhase.pickLockTime}
+        phaseStartDate={selectedPhase.startDate}
         isLocked={phaseLocked}
+        isFuture={!phaseLocked && !isCurrentPhase}
       />
       {events.length === 0 ? (
         <EmptyState
           message={`No games scheduled for ${phaseLabel(selectedPhase.seasonType, selectedPhase.weekNumber)}.`}
         />
-      ) : phaseLocked ? (
-        <ul className="flex flex-col gap-3">
-          {events.map((event) => {
-            const pick = pickByEventId.get(event.id) ?? null;
-            const locked = isPickLocked(selectedPhase, event, now);
-            return (
-              <li key={event.id}>
-                <EventPickCard
-                  event={event}
-                  homeTeam={event.homeTeam}
-                  awayTeam={event.awayTeam}
-                  odds={oddsByEventId.get(event.id) ?? null}
-                  pickType={league.pickType}
-                  selectedTeamId={pick?.teamId ?? null}
-                  frozenSpread={pick?.spreadAtLock ?? null}
-                  pickResult={pick?.pickResult ?? null}
-                  isLocked={locked}
-                />
-              </li>
-            );
-          })}
-        </ul>
+      ) : !canSubmitPicks ? (
+        eventsToShow.length === 0 ? (
+          <EmptyState message="You didn't submit picks for this week." />
+        ) : (
+          <ul className="flex flex-col gap-3">
+            {eventsToShow.map((event) => {
+              const pick = pickByEventId.get(event.id) ?? null;
+              const locked = isPickLocked(selectedPhase, event, now);
+              return (
+                <li key={event.id}>
+                  <EventPickCard
+                    event={event}
+                    homeTeam={event.homeTeam}
+                    awayTeam={event.awayTeam}
+                    odds={oddsByEventId.get(event.id) ?? null}
+                    pickType={league.pickType}
+                    selectedTeamId={pick?.teamId ?? null}
+                    frozenSpread={pick?.spreadAtLock ?? null}
+                    pickResult={pick?.pickResult ?? null}
+                    isLocked={locked}
+                  />
+                </li>
+              );
+            })}
+          </ul>
+        )
       ) : (
         <SubmitPicksForm
+          key={selectedPhase.id}
           leagueId={leagueId}
           phaseId={selectedPhase.id}
           events={events}

--- a/app/(app)/leagues/[leagueId]/my-picks/page.tsx
+++ b/app/(app)/leagues/[leagueId]/my-picks/page.tsx
@@ -4,6 +4,7 @@ import { EventPickCard } from "@/components/picks/event-pick-card";
 import { MyPicksHeader } from "@/components/picks/my-picks-header";
 import { PhaseNavigation } from "@/components/picks/phase-navigation";
 import { PickLockBanner } from "@/components/picks/pick-lock-banner";
+import { SubmitPicksForm } from "@/components/picks/submit-picks-form";
 import {
   getEventsByPhaseWithTeams,
   getOddsForEventsWithSportsbook,
@@ -111,7 +112,7 @@ export default async function MyPicksPage(
         <EmptyState
           message={`No games scheduled for ${phaseLabel(selectedPhase.seasonType, selectedPhase.weekNumber)}.`}
         />
-      ) : (
+      ) : phaseLocked ? (
         <ul className="flex flex-col gap-3">
           {events.map((event) => {
             const pick = pickByEventId.get(event.id) ?? null;
@@ -124,13 +125,26 @@ export default async function MyPicksPage(
                   awayTeam={event.awayTeam}
                   odds={oddsByEventId.get(event.id) ?? null}
                   pickType={league.pickType}
-                  pick={pick}
+                  selectedTeamId={pick?.teamId ?? null}
+                  frozenSpread={pick?.spreadAtLock ?? null}
+                  pickResult={pick?.pickResult ?? null}
                   isLocked={locked}
                 />
               </li>
             );
           })}
         </ul>
+      ) : (
+        <SubmitPicksForm
+          leagueId={leagueId}
+          phaseId={selectedPhase.id}
+          events={events}
+          oddsByEventId={Object.fromEntries(oddsByEventId)}
+          pickType={league.pickType}
+          existingPicks={picks}
+          picksPerPhase={league.picksPerPhase}
+          nowMs={now.getTime()}
+        />
       )}
     </div>
   );

--- a/app/(app)/leagues/[leagueId]/page.tsx
+++ b/app/(app)/leagues/[leagueId]/page.tsx
@@ -1,10 +1,88 @@
-import { ComingSoon } from "@/components/leagues/coming-soon";
+import { notFound } from "next/navigation";
 
-export default function LeagueStandingsPage() {
+import {
+  SeasonSwitcher,
+  type SeasonOption,
+} from "@/components/leagues/season-switcher";
+import { StandingsTable } from "@/components/leagues/standings-table";
+import { getLeagueById } from "@/data/leagues";
+import {
+  getSeasonsWithStandingsForLeague,
+  getStandingsForLeagueSeasonWithProfiles,
+} from "@/data/standings";
+import { getSeasonsBySportsLeague } from "@/data/seasons";
+import { getSession } from "@/lib/auth";
+import { selectCurrentSeason, selectStandingsSeason } from "@/lib/nfl/leagues";
+import { getAppNow } from "@/lib/simulator";
+
+export default async function LeagueStandingsPage(
+  props: PageProps<"/leagues/[leagueId]">,
+) {
+  const { leagueId } = await props.params;
+  const searchParams = await props.searchParams;
+  const session = await getSession();
+
+  const league = await getLeagueById(leagueId);
+  if (!league) notFound();
+
+  const now = await getAppNow();
+  const [seasons, seasonsWithStandings] = await Promise.all([
+    getSeasonsBySportsLeague(league.sportsLeagueId),
+    getSeasonsWithStandingsForLeague(leagueId),
+  ]);
+  const currentSeason = selectCurrentSeason(seasons, now);
+
+  const requestedSeasonId =
+    typeof searchParams.season === "string" ? searchParams.season : null;
+  const selectedSeason = selectStandingsSeason({
+    seasonsWithStandings,
+    currentSeason,
+    requestedSeasonId,
+  });
+
+  if (!selectedSeason) {
+    return (
+      <section className="rounded-lg border border-dashed p-8 text-center">
+        <p className="text-sm text-muted-foreground">
+          No season data available yet.
+        </p>
+      </section>
+    );
+  }
+
+  const standings = await getStandingsForLeagueSeasonWithProfiles(
+    leagueId,
+    selectedSeason.id,
+  );
+
+  // Dropdown draws from historical seasons; include the current season
+  // when it's not yet in the historical list so brand-new leagues still
+  // show the current year as an option rather than hiding the switcher.
+  const seasonOptions: SeasonOption[] = seasonsWithStandings.map((s) => ({
+    id: s.id,
+    year: s.year,
+  }));
+  if (
+    currentSeason &&
+    !seasonOptions.some((option) => option.id === currentSeason.id)
+  ) {
+    seasonOptions.push({ id: currentSeason.id, year: currentSeason.year });
+  }
+  // Newest first — matches every other "season list" in the app.
+  seasonOptions.sort((a, b) => b.year - a.year);
+
   return (
-    <ComingSoon
-      title="Standings"
-      description="The leaderboard shows up here once picks and scoring ship."
-    />
+    <div className="flex flex-col gap-4">
+      <header className="flex items-center justify-between gap-2">
+        <h2 className="text-lg font-semibold">Standings</h2>
+        {seasonOptions.length > 1 ? (
+          <SeasonSwitcher
+            options={seasonOptions}
+            selectedSeasonId={selectedSeason.id}
+          />
+        ) : null}
+      </header>
+      <StandingsTable standings={standings} viewerUserId={session.user.id} />
+    </div>
   );
 }

--- a/components/leagues/league-card.tsx
+++ b/components/leagues/league-card.tsx
@@ -12,10 +12,10 @@ export function LeagueCard({ league }: { league: LeagueWithMemberCount }) {
   return (
     <Link
       href={`/leagues/${league.id}`}
-      className="block focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-lg"
+      className="block h-full rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
       <Card className="h-full transition-colors hover:border-primary/50 active:bg-muted/60">
-        <CardContent className="flex items-center gap-4 p-4">
+        <CardContent className="flex h-full items-center gap-4 p-4">
           <LeagueAvatar
             name={league.name}
             imageUrl={league.imageUrl}
@@ -23,19 +23,22 @@ export function LeagueCard({ league }: { league: LeagueWithMemberCount }) {
           />
           <div className="flex min-w-0 flex-1 flex-col gap-1">
             <h3 className="truncate text-base font-semibold">{league.name}</h3>
-            <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
               <Badge variant="secondary" className="font-normal">
                 {PICK_TYPE_LABELS[league.pickType]}
               </Badge>
-              <span>{league.picksPerPhase} picks / week</span>
-              <span className="flex items-center gap-1">
+              <span className="truncate">
+                {league.picksPerPhase} picks / week
+              </span>
+            </div>
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <span className="flex shrink-0 items-center gap-1">
                 <UsersIcon className="size-3" aria-hidden />
                 {league.memberCount}/{league.size}
               </span>
+              <span aria-hidden>·</span>
+              <span className="truncate">{formatLeagueRange(league)}</span>
             </div>
-            <p className="truncate text-xs text-muted-foreground">
-              {formatLeagueRange(league)}
-            </p>
           </div>
           <ChevronRightIcon
             className="size-4 shrink-0 text-muted-foreground"

--- a/components/leagues/season-switcher.tsx
+++ b/components/leagues/season-switcher.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+export interface SeasonOption {
+  id: string;
+  year: number;
+}
+
+export function SeasonSwitcher({
+  options,
+  selectedSeasonId,
+}: {
+  options: SeasonOption[];
+  selectedSeasonId: string;
+}) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  function handleChange(value: string): void {
+    const params = new URLSearchParams(searchParams);
+    params.set("season", value);
+    router.push(`${pathname}?${params.toString()}`);
+  }
+
+  return (
+    <Select value={selectedSeasonId} onValueChange={handleChange}>
+      <SelectTrigger className="w-32">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((option) => (
+          <SelectItem key={option.id} value={option.id}>
+            {option.year}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/components/leagues/standings-table.tsx
+++ b/components/leagues/standings-table.tsx
@@ -1,0 +1,87 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { LeagueStandingWithProfile } from "@/data/standings";
+import { formatPoints } from "@/lib/nfl/scoring";
+import { getInitials } from "@/lib/utils";
+
+export function StandingsTable({
+  standings,
+  viewerUserId,
+}: {
+  standings: LeagueStandingWithProfile[];
+  viewerUserId: string;
+}) {
+  if (standings.length === 0) {
+    return (
+      <section className="rounded-lg border border-dashed p-8 text-center">
+        <p className="text-sm text-muted-foreground">
+          No standings yet. Points show up once picks start scoring.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-12">#</TableHead>
+            <TableHead>Player</TableHead>
+            <TableHead className="text-right tabular-nums">Pts</TableHead>
+            <TableHead className="text-right tabular-nums">W-L-P</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {standings.map((standing) => {
+            const isViewer = standing.userId === viewerUserId;
+            return (
+              <TableRow
+                key={standing.id}
+                className={isViewer ? "bg-primary/5" : undefined}
+              >
+                <TableCell className="font-semibold tabular-nums">
+                  {standing.rank}
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    <Avatar size="sm">
+                      {standing.profile.avatarUrl ? (
+                        <AvatarImage src={standing.profile.avatarUrl} alt="" />
+                      ) : null}
+                      <AvatarFallback>
+                        {getInitials(standing.profile.name)}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div className="flex min-w-0 flex-col">
+                      <span className="truncate text-sm font-medium">
+                        {standing.profile.name}
+                        {isViewer ? " (you)" : ""}
+                      </span>
+                      <span className="truncate text-xs text-muted-foreground">
+                        @{standing.profile.username}
+                      </span>
+                    </div>
+                  </div>
+                </TableCell>
+                <TableCell className="text-right text-base font-semibold tabular-nums">
+                  {formatPoints(standing.points)}
+                </TableCell>
+                <TableCell className="text-right text-sm tabular-nums">
+                  {standing.wins}-{standing.losses}-{standing.pushes}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/components/picks/event-pick-card.tsx
+++ b/components/picks/event-pick-card.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Image from "next/image";
-import { formatInTimeZone } from "date-fns-tz";
 import { Check, Lock } from "lucide-react";
 
 import type { OddsWithSportsbookName } from "@/data/events";
@@ -10,9 +9,8 @@ import { Card, CardContent } from "@/components/ui/card";
 import type { PickType } from "@/lib/db/schema/leagues";
 import type { PickResult } from "@/lib/db/schema/picks";
 import type { Event, Team } from "@/lib/db/schema/sports";
+import { formatEasternDateTime } from "@/lib/nfl/scheduling";
 import { cn } from "@/lib/utils";
-
-const DISPLAY_TIME_ZONE = "America/New_York";
 
 const RESULT_LABELS: Record<PickResult, string> = {
   win: "Win",
@@ -223,7 +221,7 @@ function EventStatusLine({ event }: { event: Event }) {
       <div className="flex items-center gap-2 px-1 pt-1 text-xs uppercase tracking-wide text-muted-foreground">
         <span className="font-semibold text-foreground">Final</span>
         <span>·</span>
-        <span>{formatDateTime(event.startTime)}</span>
+        <span>{formatEasternDateTime(event.startTime)}</span>
       </div>
     );
   }
@@ -239,7 +237,7 @@ function EventStatusLine({ event }: { event: Event }) {
   }
   return (
     <div className="px-1 pt-1 text-xs text-muted-foreground">
-      {formatDateTime(event.startTime)}
+      {formatEasternDateTime(event.startTime)}
     </div>
   );
 }
@@ -247,10 +245,6 @@ function EventStatusLine({ event }: { event: Event }) {
 function formatSpread(value: number): string {
   if (value > 0) return `+${value}`;
   return `${value}`;
-}
-
-function formatDateTime(date: Date): string {
-  return formatInTimeZone(date, DISPLAY_TIME_ZONE, "EEE MMM d, h:mm a 'ET'");
 }
 
 function isFinalWinner(event: Event, side: "home" | "away"): boolean {

--- a/components/picks/event-pick-card.tsx
+++ b/components/picks/event-pick-card.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Image from "next/image";
 import { formatInTimeZone } from "date-fns-tz";
 import { Check, Lock } from "lucide-react";
@@ -6,7 +8,7 @@ import type { OddsWithSportsbookName } from "@/data/events";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import type { PickType } from "@/lib/db/schema/leagues";
-import type { Pick as UserPick, PickResult } from "@/lib/db/schema/picks";
+import type { PickResult } from "@/lib/db/schema/picks";
 import type { Event, Team } from "@/lib/db/schema/sports";
 import { cn } from "@/lib/utils";
 
@@ -30,32 +32,38 @@ export function EventPickCard({
   awayTeam,
   odds,
   pickType,
-  pick,
+  selectedTeamId,
+  frozenSpread,
+  pickResult,
   isLocked,
+  onSelect,
 }: {
   event: Event;
   homeTeam: Team;
   awayTeam: Team;
   odds: OddsWithSportsbookName | null;
   pickType: PickType;
-  pick: UserPick | null;
+  selectedTeamId: string | null;
+  frozenSpread: number | null;
+  pickResult: PickResult | null;
   isLocked: boolean;
+  onSelect?: (teamId: string) => void;
 }) {
   const showScores = event.status === "in_progress" || event.status === "final";
   const showSpread = pickType === "against_the_spread";
-  const displaySpread = (side: "home" | "away"): string | null => {
+  const interactive = !isLocked && typeof onSelect === "function";
+
+  const spreadFor = (side: "home" | "away"): string | null => {
     if (!showSpread) return null;
-    // Prefer the spread frozen on the pick for the picked side, otherwise
-    // show the current live spread.
-    const picked =
-      pick && pick.teamId === (side === "home" ? homeTeam.id : awayTeam.id);
-    const frozen =
-      picked && pick?.spreadAtLock != null ? pick.spreadAtLock : null;
+    const sideTeamId = side === "home" ? homeTeam.id : awayTeam.id;
+    const isPickedSide = selectedTeamId === sideTeamId;
+    // Frozen spread only applies to the picked side; other side + unpicked
+    // cards show the current live line.
+    if (isPickedSide && frozenSpread != null) return formatSpread(frozenSpread);
     const live =
       side === "home" ? (odds?.homeSpread ?? null) : (odds?.awaySpread ?? null);
-    const value = frozen ?? live;
-    if (value == null) return null;
-    return formatSpread(value);
+    if (live == null) return null;
+    return formatSpread(live);
   };
 
   return (
@@ -64,24 +72,28 @@ export function EventPickCard({
         <TeamRow
           team={awayTeam}
           score={showScores ? event.awayScore : null}
-          spread={displaySpread("away")}
-          picked={pick?.teamId === awayTeam.id}
-          pickResult={
-            pick?.teamId === awayTeam.id ? (pick?.pickResult ?? null) : null
-          }
+          spread={spreadFor("away")}
+          picked={selectedTeamId === awayTeam.id}
+          pickResult={selectedTeamId === awayTeam.id ? pickResult : null}
           isLocked={isLocked}
           isWinner={isFinalWinner(event, "away")}
+          interactive={interactive}
+          onClick={
+            interactive && onSelect ? () => onSelect(awayTeam.id) : undefined
+          }
         />
         <TeamRow
           team={homeTeam}
           score={showScores ? event.homeScore : null}
-          spread={displaySpread("home")}
-          picked={pick?.teamId === homeTeam.id}
-          pickResult={
-            pick?.teamId === homeTeam.id ? (pick?.pickResult ?? null) : null
-          }
+          spread={spreadFor("home")}
+          picked={selectedTeamId === homeTeam.id}
+          pickResult={selectedTeamId === homeTeam.id ? pickResult : null}
           isLocked={isLocked}
           isWinner={isFinalWinner(event, "home")}
+          interactive={interactive}
+          onClick={
+            interactive && onSelect ? () => onSelect(homeTeam.id) : undefined
+          }
         />
         <EventStatusLine event={event} />
         {showSpread && odds ? (
@@ -102,6 +114,8 @@ function TeamRow({
   pickResult,
   isLocked,
   isWinner,
+  interactive,
+  onClick,
 }: {
   team: Team;
   score: number | null;
@@ -110,16 +124,11 @@ function TeamRow({
   pickResult: PickResult | null;
   isLocked: boolean;
   isWinner: boolean;
+  interactive: boolean;
+  onClick?: () => void;
 }) {
-  return (
-    <div
-      className={cn(
-        "flex items-center justify-between gap-2 rounded-md border px-3 py-2 transition-colors",
-        picked
-          ? "border-primary bg-primary/5"
-          : "border-transparent bg-muted/30",
-      )}
-    >
+  const body = (
+    <>
       <div className="flex min-w-0 items-center gap-2">
         {picked ? (
           isLocked ? (
@@ -161,8 +170,31 @@ function TeamRow({
           </span>
         ) : null}
       </div>
-    </div>
+    </>
   );
+
+  const baseClass = cn(
+    "flex items-center justify-between gap-2 rounded-md border px-3 py-2 transition-colors",
+    picked ? "border-primary bg-primary/5" : "border-transparent bg-muted/30",
+  );
+
+  if (interactive) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        aria-pressed={picked}
+        className={cn(
+          baseClass,
+          "w-full text-left hover:border-primary/60 hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        )}
+      >
+        {body}
+      </button>
+    );
+  }
+
+  return <div className={baseClass}>{body}</div>;
 }
 
 function TeamLogo({ team }: { team: Team }) {

--- a/components/picks/event-pick-card.tsx
+++ b/components/picks/event-pick-card.tsx
@@ -1,0 +1,231 @@
+import Image from "next/image";
+import { formatInTimeZone } from "date-fns-tz";
+import { Check, Lock } from "lucide-react";
+
+import type { OddsWithSportsbookName } from "@/data/events";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import type { PickType } from "@/lib/db/schema/leagues";
+import type { Pick as UserPick, PickResult } from "@/lib/db/schema/picks";
+import type { Event, Team } from "@/lib/db/schema/sports";
+import { cn } from "@/lib/utils";
+
+const DISPLAY_TIME_ZONE = "America/New_York";
+
+const RESULT_LABELS: Record<PickResult, string> = {
+  win: "Win",
+  loss: "Loss",
+  push: "Push",
+};
+
+const RESULT_CLASSES: Record<PickResult, string> = {
+  win: "bg-emerald-500/15 text-emerald-500",
+  loss: "bg-destructive/15 text-destructive",
+  push: "bg-amber-500/15 text-amber-600 dark:text-amber-400",
+};
+
+export function EventPickCard({
+  event,
+  homeTeam,
+  awayTeam,
+  odds,
+  pickType,
+  pick,
+  isLocked,
+}: {
+  event: Event;
+  homeTeam: Team;
+  awayTeam: Team;
+  odds: OddsWithSportsbookName | null;
+  pickType: PickType;
+  pick: UserPick | null;
+  isLocked: boolean;
+}) {
+  const showScores = event.status === "in_progress" || event.status === "final";
+  const showSpread = pickType === "against_the_spread";
+  const displaySpread = (side: "home" | "away"): string | null => {
+    if (!showSpread) return null;
+    // Prefer the spread frozen on the pick for the picked side, otherwise
+    // show the current live spread.
+    const picked =
+      pick && pick.teamId === (side === "home" ? homeTeam.id : awayTeam.id);
+    const frozen =
+      picked && pick?.spreadAtLock != null ? pick.spreadAtLock : null;
+    const live =
+      side === "home" ? (odds?.homeSpread ?? null) : (odds?.awaySpread ?? null);
+    const value = frozen ?? live;
+    if (value == null) return null;
+    return formatSpread(value);
+  };
+
+  return (
+    <Card size="sm" className="gap-0">
+      <CardContent className="flex flex-col gap-2 px-3 py-2">
+        <TeamRow
+          team={awayTeam}
+          score={showScores ? event.awayScore : null}
+          spread={displaySpread("away")}
+          picked={pick?.teamId === awayTeam.id}
+          pickResult={
+            pick?.teamId === awayTeam.id ? (pick?.pickResult ?? null) : null
+          }
+          isLocked={isLocked}
+          isWinner={isFinalWinner(event, "away")}
+        />
+        <TeamRow
+          team={homeTeam}
+          score={showScores ? event.homeScore : null}
+          spread={displaySpread("home")}
+          picked={pick?.teamId === homeTeam.id}
+          pickResult={
+            pick?.teamId === homeTeam.id ? (pick?.pickResult ?? null) : null
+          }
+          isLocked={isLocked}
+          isWinner={isFinalWinner(event, "home")}
+        />
+        <EventStatusLine event={event} />
+        {showSpread && odds ? (
+          <div className="px-1 pt-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+            Odds by {odds.sportsbookName}
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function TeamRow({
+  team,
+  score,
+  spread,
+  picked,
+  pickResult,
+  isLocked,
+  isWinner,
+}: {
+  team: Team;
+  score: number | null;
+  spread: string | null;
+  picked: boolean;
+  pickResult: PickResult | null;
+  isLocked: boolean;
+  isWinner: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between gap-2 rounded-md border px-3 py-2 transition-colors",
+        picked
+          ? "border-primary bg-primary/5"
+          : "border-transparent bg-muted/30",
+      )}
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        {picked ? (
+          isLocked ? (
+            <Lock
+              className="h-4 w-4 shrink-0 text-muted-foreground"
+              aria-hidden
+            />
+          ) : (
+            <Check className="h-4 w-4 shrink-0 text-primary" aria-hidden />
+          )
+        ) : null}
+        <TeamLogo team={team} />
+        <span
+          className={cn(
+            "truncate text-sm font-medium",
+            !isWinner && score != null && score > 0 && "text-muted-foreground",
+          )}
+        >
+          {team.location} {team.name}
+        </span>
+        {spread ? (
+          <span className="text-xs text-muted-foreground tabular-nums">
+            {spread}
+          </span>
+        ) : null}
+      </div>
+      <div className="flex items-center gap-2">
+        {pickResult ? (
+          <Badge
+            variant="secondary"
+            className={cn("px-2 py-0 text-xs", RESULT_CLASSES[pickResult])}
+          >
+            {RESULT_LABELS[pickResult]}
+          </Badge>
+        ) : null}
+        {score != null ? (
+          <span className="w-8 text-right text-base font-semibold tabular-nums">
+            {score}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function TeamLogo({ team }: { team: Team }) {
+  if (!team.logoUrl) {
+    return (
+      <span className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-semibold">
+        {team.abbreviation}
+      </span>
+    );
+  }
+  return (
+    <Image
+      src={team.logoUrl}
+      alt=""
+      width={24}
+      height={24}
+      className="h-6 w-6 shrink-0 object-contain"
+      unoptimized
+    />
+  );
+}
+
+function EventStatusLine({ event }: { event: Event }) {
+  if (event.status === "final") {
+    return (
+      <div className="flex items-center gap-2 px-1 pt-1 text-xs uppercase tracking-wide text-muted-foreground">
+        <span className="font-semibold text-foreground">Final</span>
+        <span>·</span>
+        <span>{formatDateTime(event.startTime)}</span>
+      </div>
+    );
+  }
+  if (event.status === "in_progress") {
+    return (
+      <div className="flex items-center gap-2 px-1 pt-1 text-xs uppercase tracking-wide">
+        <span className="inline-flex items-center gap-1 font-semibold text-emerald-500">
+          <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-emerald-500" />
+          Live
+        </span>
+      </div>
+    );
+  }
+  return (
+    <div className="px-1 pt-1 text-xs text-muted-foreground">
+      {formatDateTime(event.startTime)}
+    </div>
+  );
+}
+
+function formatSpread(value: number): string {
+  if (value > 0) return `+${value}`;
+  return `${value}`;
+}
+
+function formatDateTime(date: Date): string {
+  return formatInTimeZone(date, DISPLAY_TIME_ZONE, "EEE MMM d, h:mm a 'ET'");
+}
+
+function isFinalWinner(event: Event, side: "home" | "away"): boolean {
+  if (event.status !== "final") return false;
+  if (event.homeScore == null || event.awayScore == null) return false;
+  if (event.homeScore === event.awayScore) return false;
+  return side === "home"
+    ? event.homeScore > event.awayScore
+    : event.awayScore > event.homeScore;
+}

--- a/components/picks/event-pick-card.tsx
+++ b/components/picks/event-pick-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { Check, Lock } from "lucide-react";
+import { Check, CircleDot, Lock, Minus, X } from "lucide-react";
 
 import type { OddsWithSportsbookName } from "@/data/events";
 import { Badge } from "@/components/ui/badge";
@@ -24,6 +24,15 @@ const RESULT_CLASSES: Record<PickResult, string> = {
   push: "bg-amber-500/15 text-amber-600 dark:text-amber-400",
 };
 
+// Border + background tint applied to the picked team row once the game
+// is scored. Mirrors the result badge colors so the outcome reads at a
+// glance without relying on the badge alone.
+const RESULT_ROW_CLASSES: Record<PickResult, string> = {
+  win: "border-emerald-500/70 bg-emerald-500/10",
+  loss: "border-destructive/70 bg-destructive/10",
+  push: "border-amber-500/70 bg-amber-500/10",
+};
+
 export function EventPickCard({
   event,
   homeTeam,
@@ -32,6 +41,7 @@ export function EventPickCard({
   pickType,
   selectedTeamId,
   frozenSpread,
+  priorFrozenSpread = null,
   pickResult,
   isLocked,
   onSelect,
@@ -43,6 +53,7 @@ export function EventPickCard({
   pickType: PickType;
   selectedTeamId: string | null;
   frozenSpread: number | null;
+  priorFrozenSpread?: number | null;
   pickResult: PickResult | null;
   isLocked: boolean;
   onSelect?: (teamId: string) => void;
@@ -51,18 +62,51 @@ export function EventPickCard({
   const showSpread = pickType === "against_the_spread";
   const interactive = !isLocked && typeof onSelect === "function";
 
-  const spreadFor = (side: "home" | "away"): string | null => {
+  const spreadFor = (
+    side: "home" | "away",
+  ): { value: string; hint: string | null } | null => {
     if (!showSpread) return null;
     const sideTeamId = side === "home" ? homeTeam.id : awayTeam.id;
     const isPickedSide = selectedTeamId === sideTeamId;
-    // Frozen spread only applies to the picked side; other side + unpicked
-    // cards show the current live line.
-    if (isPickedSide && frozenSpread != null) return formatSpread(frozenSpread);
+    // When a frozen spread exists (saved pick, clean state or post-lock),
+    // show it on BOTH sides — spreads are zero-sum, so the unpicked side's
+    // frozen value is the negation. This avoids the visual mismatch where
+    // the picked team would show -3.5 and the opponent would show the new
+    // live +7 after a line move.
+    if (frozenSpread != null && selectedTeamId != null) {
+      const signed = isPickedSide ? frozenSpread : -frozenSpread;
+      return { value: formatSpread(signed), hint: null };
+    }
     const live =
       side === "home" ? (odds?.homeSpread ?? null) : (odds?.awaySpread ?? null);
     if (live == null) return null;
-    return formatSpread(live);
+    // When we're rendering live on the picked side and a prior frozen spread
+    // exists (user has saved picks but is currently editing), surface the
+    // delta so they can see what re-submitting will change.
+    const hint =
+      isPickedSide && priorFrozenSpread != null && priorFrozenSpread !== live
+        ? `was ${formatSpread(priorFrozenSpread)}`
+        : null;
+    return { value: formatSpread(live), hint };
   };
+
+  // Pre-lock "line moved" indicator: when we're displaying the frozen
+  // spread on both sides but the current live line differs, surface the
+  // movement on the card itself so the user can see where the line is now.
+  // Suppressed post-lock — the live line isn't relevant once the pick is
+  // final.
+  const pickedLiveSpread =
+    !isLocked && frozenSpread != null && selectedTeamId != null
+      ? selectedTeamId === homeTeam.id
+        ? (odds?.homeSpread ?? null)
+        : selectedTeamId === awayTeam.id
+          ? (odds?.awaySpread ?? null)
+          : null
+      : null;
+  const lineMoved =
+    frozenSpread != null &&
+    pickedLiveSpread != null &&
+    pickedLiveSpread !== frozenSpread;
 
   return (
     <Card size="sm" className="gap-0">
@@ -94,6 +138,12 @@ export function EventPickCard({
           }
         />
         <EventStatusLine event={event} />
+        {lineMoved && frozenSpread != null && pickedLiveSpread != null ? (
+          <div className="px-1 pt-1 text-[10px] uppercase tracking-wide text-amber-600 dark:text-amber-400">
+            Spread moved · {formatSpread(frozenSpread)} →{" "}
+            {formatSpread(pickedLiveSpread)}
+          </div>
+        ) : null}
         {showSpread && odds ? (
           <div className="px-1 pt-1 text-[10px] uppercase tracking-wide text-muted-foreground">
             Odds by {odds.sportsbookName}
@@ -117,7 +167,7 @@ function TeamRow({
 }: {
   team: Team;
   score: number | null;
-  spread: string | null;
+  spread: { value: string; hint: string | null } | null;
   picked: boolean;
   pickResult: PickResult | null;
   isLocked: boolean;
@@ -129,13 +179,25 @@ function TeamRow({
     <>
       <div className="flex min-w-0 items-center gap-2">
         {picked ? (
-          isLocked ? (
+          pickResult === "win" ? (
+            <Check className="h-4 w-4 shrink-0 text-emerald-500" aria-hidden />
+          ) : pickResult === "loss" ? (
+            <X className="h-4 w-4 shrink-0 text-destructive" aria-hidden />
+          ) : pickResult === "push" ? (
+            <Minus
+              className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400"
+              aria-hidden
+            />
+          ) : isLocked ? (
             <Lock
               className="h-4 w-4 shrink-0 text-muted-foreground"
               aria-hidden
             />
           ) : (
-            <Check className="h-4 w-4 shrink-0 text-primary" aria-hidden />
+            // Unscored + editable — radio-dot glyph rather than a check so
+            // "selected" doesn't read as "correct" once other rows show the
+            // result-colored Check.
+            <CircleDot className="h-4 w-4 shrink-0 text-primary" aria-hidden />
           )
         ) : null}
         <TeamLogo team={team} />
@@ -148,8 +210,13 @@ function TeamRow({
           {team.location} {team.name}
         </span>
         {spread ? (
-          <span className="text-xs text-muted-foreground tabular-nums">
-            {spread}
+          <span className="flex items-baseline gap-1 text-xs tabular-nums">
+            <span className="text-muted-foreground">{spread.value}</span>
+            {spread.hint ? (
+              <span className="text-amber-600 dark:text-amber-400">
+                ({spread.hint})
+              </span>
+            ) : null}
           </span>
         ) : null}
       </div>
@@ -171,9 +238,12 @@ function TeamRow({
     </>
   );
 
+  const pickedClasses = pickResult
+    ? RESULT_ROW_CLASSES[pickResult]
+    : "border-primary bg-primary/5";
   const baseClass = cn(
     "flex items-center justify-between gap-2 rounded-md border px-3 py-2 transition-colors",
-    picked ? "border-primary bg-primary/5" : "border-transparent bg-muted/30",
+    picked ? pickedClasses : "border-transparent bg-muted/30",
   );
 
   if (interactive) {

--- a/components/picks/member-picks-card.tsx
+++ b/components/picks/member-picks-card.tsx
@@ -7,11 +7,12 @@ import type { EventWithTeams } from "@/data/events";
 import type { LeagueStandingWithProfile } from "@/data/standings";
 import type { PickType } from "@/lib/db/schema/leagues";
 import type { Pick } from "@/lib/db/schema/picks";
-import { formatPoints } from "@/lib/nfl/scoring";
+import { formatPoints, type WeeklyStanding } from "@/lib/nfl/scoring";
 import { getInitials } from "@/lib/utils";
 
 export function MemberPicksCard({
   standing,
+  weekly,
   picks,
   events,
   oddsByEventId,
@@ -20,6 +21,7 @@ export function MemberPicksCard({
   defaultOpen,
 }: {
   standing: LeagueStandingWithProfile;
+  weekly: WeeklyStanding | null;
   picks: Pick[];
   events: EventWithTeams[];
   oddsByEventId: Map<string, OddsWithSportsbookName>;
@@ -28,6 +30,10 @@ export function MemberPicksCard({
   defaultOpen: boolean;
 }) {
   const pickByEventId = new Map(picks.map((p) => [p.eventId, p]));
+  // Only show games this member actually picked — the other events on the
+  // phase are noise once picks are locked. Same rationale as the My Picks
+  // filter.
+  const pickedEvents = events.filter((e) => pickByEventId.has(e.id));
 
   return (
     <details
@@ -51,11 +57,17 @@ export function MemberPicksCard({
           </span>
         </div>
         <div className="flex flex-col items-end text-right">
-          <span className="text-base font-semibold tabular-nums">
-            {formatPoints(standing.points)} pts
-          </span>
+          {weekly ? (
+            <span className="text-base font-semibold tabular-nums">
+              {weekly.wins}-{weekly.losses}-{weekly.pushes}
+              <span className="ml-1 text-xs font-normal text-muted-foreground">
+                wk · {formatPoints(weekly.points)}
+              </span>
+            </span>
+          ) : null}
           <span className="text-xs text-muted-foreground tabular-nums">
-            {standing.wins}-{standing.losses}-{standing.pushes}
+            {standing.wins}-{standing.losses}-{standing.pushes} overall ·{" "}
+            {formatPoints(standing.points)}
           </span>
         </div>
         <ChevronDown
@@ -66,9 +78,13 @@ export function MemberPicksCard({
       <div className="border-t p-3">
         {events.length === 0 ? (
           <p className="text-sm text-muted-foreground">No games this phase.</p>
+        ) : pickedEvents.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No picks submitted for this week.
+          </p>
         ) : (
           <ul className="flex flex-col gap-2">
-            {events.map((event) => {
+            {pickedEvents.map((event) => {
               const pick = pickByEventId.get(event.id) ?? null;
               return (
                 <li key={event.id}>

--- a/components/picks/member-picks-card.tsx
+++ b/components/picks/member-picks-card.tsx
@@ -1,0 +1,94 @@
+import { ChevronDown } from "lucide-react";
+
+import { EventPickCard } from "@/components/picks/event-pick-card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import type { OddsWithSportsbookName } from "@/data/events";
+import type { EventWithTeams } from "@/data/events";
+import type { LeagueStandingWithProfile } from "@/data/standings";
+import type { PickType } from "@/lib/db/schema/leagues";
+import type { Pick } from "@/lib/db/schema/picks";
+import { formatPoints } from "@/lib/nfl/scoring";
+import { getInitials } from "@/lib/utils";
+
+export function MemberPicksCard({
+  standing,
+  picks,
+  events,
+  oddsByEventId,
+  pickType,
+  isViewer,
+  defaultOpen,
+}: {
+  standing: LeagueStandingWithProfile;
+  picks: Pick[];
+  events: EventWithTeams[];
+  oddsByEventId: Map<string, OddsWithSportsbookName>;
+  pickType: PickType;
+  isViewer: boolean;
+  defaultOpen: boolean;
+}) {
+  const pickByEventId = new Map(picks.map((p) => [p.eventId, p]));
+
+  return (
+    <details
+      className="group rounded-lg border border-border bg-card"
+      open={defaultOpen}
+    >
+      <summary className="flex cursor-pointer list-none items-center gap-3 p-3 [&::-webkit-details-marker]:hidden">
+        <Avatar size="sm">
+          {standing.profile.avatarUrl ? (
+            <AvatarImage src={standing.profile.avatarUrl} alt="" />
+          ) : null}
+          <AvatarFallback>{getInitials(standing.profile.name)}</AvatarFallback>
+        </Avatar>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <span className="truncate text-sm font-medium">
+            {standing.profile.name}
+            {isViewer ? " (you)" : ""}
+          </span>
+          <span className="truncate text-xs text-muted-foreground">
+            @{standing.profile.username}
+          </span>
+        </div>
+        <div className="flex flex-col items-end text-right">
+          <span className="text-base font-semibold tabular-nums">
+            {formatPoints(standing.points)} pts
+          </span>
+          <span className="text-xs text-muted-foreground tabular-nums">
+            {standing.wins}-{standing.losses}-{standing.pushes}
+          </span>
+        </div>
+        <ChevronDown
+          className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180"
+          aria-hidden
+        />
+      </summary>
+      <div className="border-t p-3">
+        {events.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No games this phase.</p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {events.map((event) => {
+              const pick = pickByEventId.get(event.id) ?? null;
+              return (
+                <li key={event.id}>
+                  <EventPickCard
+                    event={event}
+                    homeTeam={event.homeTeam}
+                    awayTeam={event.awayTeam}
+                    odds={oddsByEventId.get(event.id) ?? null}
+                    pickType={pickType}
+                    selectedTeamId={pick?.teamId ?? null}
+                    frozenSpread={pick?.spreadAtLock ?? null}
+                    pickResult={pick?.pickResult ?? null}
+                    isLocked
+                  />
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </details>
+  );
+}

--- a/components/picks/my-picks-header.tsx
+++ b/components/picks/my-picks-header.tsx
@@ -1,48 +1,75 @@
 import type { LeagueStanding } from "@/lib/db/schema/leagues";
 import { formatPoints } from "@/lib/nfl/scoring";
 
+export interface StandingSummary {
+  rank: number;
+  wins: number;
+  losses: number;
+  pushes: number;
+  points: number;
+}
+
 export function MyPicksHeader({
   standing,
+  weekly,
   memberCount,
 }: {
   standing: LeagueStanding | null;
+  weekly: StandingSummary | null;
   memberCount: number;
 }) {
-  const rank = standing?.rank ?? 1;
-  const wins = standing?.wins ?? 0;
-  const losses = standing?.losses ?? 0;
-  const pushes = standing?.pushes ?? 0;
-  const points = standing?.points ?? 0;
+  const overall: StandingSummary = {
+    rank: standing?.rank ?? 1,
+    wins: standing?.wins ?? 0,
+    losses: standing?.losses ?? 0,
+    pushes: standing?.pushes ?? 0,
+    points: standing?.points ?? 0,
+  };
 
   return (
-    <section className="flex flex-wrap items-center justify-between gap-4 rounded-lg border border-border bg-card px-4 py-3">
-      <div className="flex flex-col">
-        <span className="text-xs uppercase tracking-wide text-muted-foreground">
-          Rank
-        </span>
-        <span className="text-2xl font-bold tabular-nums">
-          {rank}
-          <span className="ml-1 text-sm font-normal text-muted-foreground">
-            of {memberCount}
-          </span>
-        </span>
-      </div>
-      <div className="flex flex-col items-end">
-        <span className="text-xs uppercase tracking-wide text-muted-foreground">
-          Record
-        </span>
-        <span className="text-sm font-medium tabular-nums">
-          {wins}-{losses}-{pushes}
-        </span>
-      </div>
-      <div className="flex flex-col items-end">
-        <span className="text-xs uppercase tracking-wide text-muted-foreground">
-          Points
-        </span>
-        <span className="text-2xl font-bold tabular-nums">
-          {formatPoints(points)}
-        </span>
-      </div>
+    <section className="flex flex-col gap-2 rounded-lg border border-border bg-card px-4 py-3">
+      <StandingsRow
+        label="Overall"
+        summary={overall}
+        memberCount={memberCount}
+      />
+      {weekly ? (
+        <StandingsRow
+          label="This Week"
+          summary={weekly}
+          memberCount={memberCount}
+        />
+      ) : null}
     </section>
+  );
+}
+
+function StandingsRow({
+  label,
+  summary,
+  memberCount,
+}: {
+  label: string;
+  summary: StandingSummary;
+  memberCount: number;
+}) {
+  return (
+    <div className="grid grid-cols-[6rem_1fr_auto_auto] items-baseline gap-x-3">
+      <span className="text-xs uppercase tracking-wide text-muted-foreground">
+        {label}
+      </span>
+      <span className="text-lg font-bold tabular-nums">
+        #{summary.rank}
+        <span className="ml-1 text-xs font-normal text-muted-foreground">
+          of {memberCount}
+        </span>
+      </span>
+      <span className="text-sm tabular-nums text-muted-foreground">
+        {summary.wins}-{summary.losses}-{summary.pushes}
+      </span>
+      <span className="text-lg font-bold tabular-nums">
+        {formatPoints(summary.points)}
+      </span>
+    </div>
   );
 }

--- a/components/picks/my-picks-header.tsx
+++ b/components/picks/my-picks-header.tsx
@@ -32,8 +32,7 @@ export function MyPicksHeader({
           Record
         </span>
         <span className="text-sm font-medium tabular-nums">
-          {wins}-{losses}
-          {pushes > 0 ? `-${pushes}` : ""}
+          {wins}-{losses}-{pushes}
         </span>
       </div>
       <div className="flex flex-col items-end">

--- a/components/picks/my-picks-header.tsx
+++ b/components/picks/my-picks-header.tsx
@@ -1,4 +1,5 @@
 import type { LeagueStanding } from "@/lib/db/schema/leagues";
+import { formatPoints } from "@/lib/nfl/scoring";
 
 export function MyPicksHeader({
   standing,
@@ -45,9 +46,4 @@ export function MyPicksHeader({
       </div>
     </section>
   );
-}
-
-function formatPoints(points: number): string {
-  if (Number.isInteger(points)) return points.toString();
-  return points.toFixed(1);
 }

--- a/components/picks/my-picks-header.tsx
+++ b/components/picks/my-picks-header.tsx
@@ -1,0 +1,53 @@
+import type { LeagueStanding } from "@/lib/db/schema/leagues";
+
+export function MyPicksHeader({
+  standing,
+  memberCount,
+}: {
+  standing: LeagueStanding | null;
+  memberCount: number;
+}) {
+  const rank = standing?.rank ?? 1;
+  const wins = standing?.wins ?? 0;
+  const losses = standing?.losses ?? 0;
+  const pushes = standing?.pushes ?? 0;
+  const points = standing?.points ?? 0;
+
+  return (
+    <section className="flex flex-wrap items-center justify-between gap-4 rounded-lg border border-border bg-card px-4 py-3">
+      <div className="flex flex-col">
+        <span className="text-xs uppercase tracking-wide text-muted-foreground">
+          Rank
+        </span>
+        <span className="text-2xl font-bold tabular-nums">
+          {rank}
+          <span className="ml-1 text-sm font-normal text-muted-foreground">
+            of {memberCount}
+          </span>
+        </span>
+      </div>
+      <div className="flex flex-col items-end">
+        <span className="text-xs uppercase tracking-wide text-muted-foreground">
+          Record
+        </span>
+        <span className="text-sm font-medium tabular-nums">
+          {wins}-{losses}
+          {pushes > 0 ? `-${pushes}` : ""}
+        </span>
+      </div>
+      <div className="flex flex-col items-end">
+        <span className="text-xs uppercase tracking-wide text-muted-foreground">
+          Points
+        </span>
+        <span className="text-2xl font-bold tabular-nums">
+          {formatPoints(points)}
+        </span>
+      </div>
+    </section>
+  );
+}
+
+function formatPoints(points: number): string {
+  if (Number.isInteger(points)) return points.toString();
+  return points.toFixed(1);
+}

--- a/components/picks/phase-navigation.tsx
+++ b/components/picks/phase-navigation.tsx
@@ -1,0 +1,70 @@
+import Link from "next/link";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import type { Phase } from "@/lib/db/schema/sports";
+import { phaseLabel } from "@/lib/nfl/leagues";
+import { cn } from "@/lib/utils";
+
+export function PhaseNavigation({
+  basePath,
+  currentPhase,
+  prevPhase,
+  nextPhase,
+}: {
+  basePath: string;
+  currentPhase: Phase;
+  prevPhase: Phase | null;
+  nextPhase: Phase | null;
+}) {
+  return (
+    <nav
+      aria-label="Phase navigation"
+      className="flex items-center justify-between gap-2"
+    >
+      <Button
+        asChild={!!prevPhase}
+        variant="ghost"
+        size="sm"
+        disabled={!prevPhase}
+        className={cn("gap-1", !prevPhase && "pointer-events-none opacity-40")}
+      >
+        {prevPhase ? (
+          <Link href={`${basePath}?phase=${prevPhase.id}`}>
+            <ChevronLeft className="h-4 w-4" />
+            <span className="sr-only sm:not-sr-only">
+              {phaseLabel(prevPhase.seasonType, prevPhase.weekNumber)}
+            </span>
+          </Link>
+        ) : (
+          <span>
+            <ChevronLeft className="h-4 w-4" />
+          </span>
+        )}
+      </Button>
+      <div className="text-center text-sm font-semibold">
+        {phaseLabel(currentPhase.seasonType, currentPhase.weekNumber)}
+      </div>
+      <Button
+        asChild={!!nextPhase}
+        variant="ghost"
+        size="sm"
+        disabled={!nextPhase}
+        className={cn("gap-1", !nextPhase && "pointer-events-none opacity-40")}
+      >
+        {nextPhase ? (
+          <Link href={`${basePath}?phase=${nextPhase.id}`}>
+            <span className="sr-only sm:not-sr-only">
+              {phaseLabel(nextPhase.seasonType, nextPhase.weekNumber)}
+            </span>
+            <ChevronRight className="h-4 w-4" />
+          </Link>
+        ) : (
+          <span>
+            <ChevronRight className="h-4 w-4" />
+          </span>
+        )}
+      </Button>
+    </nav>
+  );
+}

--- a/components/picks/pick-lock-banner.tsx
+++ b/components/picks/pick-lock-banner.tsx
@@ -1,0 +1,41 @@
+import { formatInTimeZone } from "date-fns-tz";
+import { Lock, Unlock } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const DISPLAY_TIME_ZONE = "America/New_York";
+
+export function PickLockBanner({
+  pickLockTime,
+  isLocked,
+}: {
+  pickLockTime: Date;
+  isLocked: boolean;
+}) {
+  const formatted = formatInTimeZone(
+    pickLockTime,
+    DISPLAY_TIME_ZONE,
+    "EEE MMM d, h:mm a 'ET'",
+  );
+
+  return (
+    <div
+      role="status"
+      className={cn(
+        "flex items-center gap-2 rounded-md border px-3 py-2 text-sm",
+        isLocked
+          ? "border-destructive/40 bg-destructive/10 text-destructive"
+          : "border-border bg-muted/40 text-muted-foreground",
+      )}
+    >
+      {isLocked ? (
+        <Lock className="h-4 w-4" aria-hidden />
+      ) : (
+        <Unlock className="h-4 w-4" aria-hidden />
+      )}
+      <span>
+        {isLocked ? "Picks locked for this phase" : `Picks lock ${formatted}`}
+      </span>
+    </div>
+  );
+}

--- a/components/picks/pick-lock-banner.tsx
+++ b/components/picks/pick-lock-banner.tsx
@@ -1,9 +1,7 @@
-import { formatInTimeZone } from "date-fns-tz";
 import { Lock, Unlock } from "lucide-react";
 
+import { formatEasternDateTime } from "@/lib/nfl/scheduling";
 import { cn } from "@/lib/utils";
-
-const DISPLAY_TIME_ZONE = "America/New_York";
 
 export function PickLockBanner({
   pickLockTime,
@@ -12,11 +10,7 @@ export function PickLockBanner({
   pickLockTime: Date;
   isLocked: boolean;
 }) {
-  const formatted = formatInTimeZone(
-    pickLockTime,
-    DISPLAY_TIME_ZONE,
-    "EEE MMM d, h:mm a 'ET'",
-  );
+  const formatted = formatEasternDateTime(pickLockTime);
 
   return (
     <div

--- a/components/picks/pick-lock-banner.tsx
+++ b/components/picks/pick-lock-banner.tsx
@@ -1,35 +1,41 @@
-import { Lock, Unlock } from "lucide-react";
+import { Clock, Lock, Unlock } from "lucide-react";
 
 import { formatEasternDateTime } from "@/lib/nfl/scheduling";
 import { cn } from "@/lib/utils";
 
 export function PickLockBanner({
   pickLockTime,
+  phaseStartDate,
   isLocked,
+  isFuture = false,
 }: {
   pickLockTime: Date;
+  phaseStartDate: Date;
   isLocked: boolean;
+  isFuture?: boolean;
 }) {
-  const formatted = formatEasternDateTime(pickLockTime);
+  const variant = isLocked ? "locked" : isFuture ? "future" : "open";
+  const Icon =
+    variant === "locked" ? Lock : variant === "future" ? Clock : Unlock;
+  const message =
+    variant === "locked"
+      ? "Picks locked for this phase"
+      : variant === "future"
+        ? `This week opens for picks ${formatEasternDateTime(phaseStartDate)}`
+        : `Picks lock ${formatEasternDateTime(pickLockTime)}`;
 
   return (
     <div
       role="status"
       className={cn(
         "flex items-center gap-2 rounded-md border px-3 py-2 text-sm",
-        isLocked
+        variant === "locked"
           ? "border-destructive/40 bg-destructive/10 text-destructive"
           : "border-border bg-muted/40 text-muted-foreground",
       )}
     >
-      {isLocked ? (
-        <Lock className="h-4 w-4" aria-hidden />
-      ) : (
-        <Unlock className="h-4 w-4" aria-hidden />
-      )}
-      <span>
-        {isLocked ? "Picks locked for this phase" : `Picks lock ${formatted}`}
-      </span>
+      <Icon className="h-4 w-4" aria-hidden />
+      <span>{message}</span>
     </div>
   );
 }

--- a/components/picks/submit-picks-form.tsx
+++ b/components/picks/submit-picks-form.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useMemo, useState, useTransition } from "react";
+import { useEffect, useMemo, useState, useTransition } from "react";
+import { AlertTriangle, Check, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 
 import { submitPicksAction } from "@/actions/picks";
@@ -10,6 +11,8 @@ import { Button } from "@/components/ui/button";
 import type { EventWithTeams, OddsWithSportsbookName } from "@/data/events";
 import type { PickType } from "@/lib/db/schema/leagues";
 import type { Pick } from "@/lib/db/schema/picks";
+import { hasEventStarted } from "@/lib/nfl/leagues";
+import { formatEasternDateTime } from "@/lib/nfl/scheduling";
 
 export function SubmitPicksForm({
   leagueId,
@@ -33,31 +36,92 @@ export function SubmitPicksForm({
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
 
+  // Live-tick the client's notion of "now" forward from the server's
+  // snapshot so per-event lock transitions fire without a page refresh.
+  // Without this, a game that kicks off while the form is open stays
+  // visually interactive and the user only finds out on submit failure.
+  const [currentNowMs, setCurrentNowMs] = useState(nowMs);
+  useEffect(() => {
+    const startReal = Date.now();
+    const interval = setInterval(() => {
+      setCurrentNowMs(nowMs + (Date.now() - startReal));
+    }, 30_000);
+    return () => clearInterval(interval);
+  }, [nowMs]);
+
+  const currentNow = useMemo(() => new Date(currentNowMs), [currentNowMs]);
   const unstartedEvents = useMemo(
-    () => events.filter((e) => nowMs < e.startTime.getTime()),
-    [events, nowMs],
+    () => events.filter((e) => !hasEventStarted(e, currentNow)),
+    [events, currentNow],
   );
-  const lockedEvents = useMemo(
-    () => events.filter((e) => nowMs >= e.startTime.getTime()),
-    [events, nowMs],
+
+  const unstartedEventIds = useMemo(
+    () => new Set(unstartedEvents.map((e) => e.id)),
+    [unstartedEvents],
   );
-  const requiredCount = Math.min(picksPerPhase, unstartedEvents.length);
+  const existingPickEventIds = useMemo(
+    () => new Set(existingPicks.map((p) => p.eventId)),
+    [existingPicks],
+  );
+  // Locked picks are started games the viewer picked — render them in
+  // their own section so the user can see their in-flight / final picks
+  // alongside the games they still need to pick. Started games the user
+  // didn't pick are hidden — noise on My Picks.
+  const lockedPickedEvents = useMemo(
+    () =>
+      events.filter(
+        (e) => hasEventStarted(e, currentNow) && existingPickEventIds.has(e.id),
+      ),
+    [events, currentNow, existingPickEventIds],
+  );
+  // Existing picks on started events count against the league's
+  // picksPerPhase budget — they're locked in and preserved. Required
+  // count is the remaining quota available in this submission; never
+  // negative, never more than the unstarted pool.
+  const lockedPickCount = lockedPickedEvents.length;
+  const requiredCount = Math.min(
+    Math.max(picksPerPhase - lockedPickCount, 0),
+    unstartedEvents.length,
+  );
 
   const existingPickByEventId = useMemo(
     () => new Map(existingPicks.map((p) => [p.eventId, p])),
     [existingPicks],
   );
 
-  const [selections, setSelections] = useState<Map<string, string>>(() => {
-    const initial = new Map<string, string>();
+  // Saved selections scoped to unstarted events — these are the picks the
+  // user can still change. Started-game picks are preserved server-side and
+  // don't participate in dirty-state.
+  const savedSelections = useMemo(() => {
+    const map = new Map<string, string>();
     for (const event of unstartedEvents) {
       const prior = existingPickByEventId.get(event.id);
-      if (prior) initial.set(event.id, prior.teamId);
+      if (prior) map.set(event.id, prior.teamId);
     }
-    return initial;
-  });
+    return map;
+  }, [unstartedEvents, existingPickByEventId]);
+
+  const hasSubmittedBefore = existingPicks.length > 0;
+  const lastSavedAt = useMemo(() => {
+    if (existingPicks.length === 0) return null;
+    return new Date(
+      Math.max(...existingPicks.map((p) => p.updatedAt.getTime())),
+    );
+  }, [existingPicks]);
+
+  const [selections, setSelections] = useState<Map<string, string>>(
+    () => new Map(savedSelections),
+  );
 
   function togglePick(eventId: string, teamId: string): void {
+    // Defensive check — if the card is visually still interactive but the
+    // event isn't in the editable set (stale render, admin-overridden
+    // status, or a game that kicked off between renders), reject the
+    // click outright. Belt-and-suspenders with the auto-prune below.
+    if (!unstartedEventIds.has(eventId)) {
+      toast.error("That game has already started — its pick is locked.");
+      return;
+    }
     setSelections((prev) => {
       const next = new Map(prev);
       const current = next.get(eventId);
@@ -76,18 +140,88 @@ export function SubmitPicksForm({
     });
   }
 
+  // Auto-prune selections that reference events no longer in the
+  // editable set. This runs whenever `unstartedEvents` changes (a game
+  // kicked off per the ticker, a fresh fetch delivered an updated event
+  // list, etc.) and keeps `selections` a strict subset of
+  // `unstartedEventIds`. Single source of truth: if the event isn't in
+  // `unstartedEvents`, it can't be in `selections`.
+  useEffect(() => {
+    const prunable = Array.from(selections.keys()).filter(
+      (eventId) => !unstartedEventIds.has(eventId),
+    );
+    if (prunable.length === 0) return;
+    setSelections((prev) => {
+      const next = new Map(prev);
+      for (const id of prunable) next.delete(id);
+      return next;
+    });
+    toast.info(
+      prunable.length === 1
+        ? "A game started — your selection was removed."
+        : `${prunable.length} games started — your selections were removed.`,
+    );
+  }, [unstartedEventIds, selections]);
+
   const picksMade = selections.size;
-  const canSubmit = picksMade === requiredCount && requiredCount > 0;
+
+  const isDirty = useMemo(() => {
+    if (selections.size !== savedSelections.size) return true;
+    for (const [eventId, teamId] of selections) {
+      if (savedSelections.get(eventId) !== teamId) return true;
+    }
+    return false;
+  }, [selections, savedSelections]);
+
+  const isComplete = picksMade === requiredCount && requiredCount > 0;
+  const canSubmit = isComplete && isDirty;
+  const showAtsRefreshBanner =
+    isDirty && pickType === "against_the_spread" && hasSubmittedBefore;
+
+  // Reset target is "saved if any, else empty." Button is only useful when
+  // current selections differ from the reset target — that's the single
+  // condition for both "start over" (no saved picks) and "undo my edits"
+  // (saved picks + dirty) cases.
+  const canReset = hasSubmittedBefore ? isDirty : selections.size > 0;
+  const resetLabel = hasSubmittedBefore ? "Revert changes" : "Clear picks";
+
+  function handleReset(): void {
+    setSelections(new Map(savedSelections));
+  }
+
+  function liveSpreadFor(eventId: string, teamId: string): number | null {
+    const event = events.find((e) => e.id === eventId);
+    const odds = oddsByEventId[eventId];
+    if (!event || !odds) return null;
+    return teamId === event.homeTeamId
+      ? (odds.homeSpread ?? null)
+      : (odds.awaySpread ?? null);
+  }
 
   function handleSubmit(): void {
     const picks = Array.from(selections.entries()).map(([eventId, teamId]) => ({
       eventId,
       teamId,
+      // Always include expectedSpread when we have it — the action only
+      // validates it for ATS leagues. This is the spread the user saw for
+      // their picked team at submit time; the server rejects with
+      // STALE_ODDS if the line has moved since.
+      expectedSpread:
+        pickType === "against_the_spread"
+          ? liveSpreadFor(eventId, teamId)
+          : null,
     }));
     startTransition(async () => {
       const result = await submitPicksAction({ leagueId, phaseId, picks });
       if (!result.success) {
         toast.error(result.error);
+        // Any server rejection means the client's view of the phase may
+        // be stale — odds moved, a game kicked off, an admin overrode a
+        // status, etc. Refresh so the RSC tree re-fetches and the form's
+        // `events` / `odds` props catch up. Local `selections` survive
+        // since they're client state; the auto-prune effect will drop
+        // anything that references a now-started event.
+        router.refresh();
         return;
       }
       toast.success("Picks saved");
@@ -95,57 +229,207 @@ export function SubmitPicksForm({
     });
   }
 
+  // "Take latest odds" banner: ATS only, saved picks, clean state, and at
+  // least one pick whose frozen spread differs from the current live line.
+  // Clicking the button re-submits with the same selections — the action
+  // refreshes `spreadAtLock` from current odds (the §9.3 atomic refresh).
+  const movedPickCount = useMemo(() => {
+    if (pickType !== "against_the_spread") return 0;
+    if (!hasSubmittedBefore || isDirty) return 0;
+    let count = 0;
+    for (const [eventId, teamId] of savedSelections) {
+      const saved = existingPickByEventId.get(eventId);
+      const live = liveSpreadFor(eventId, teamId);
+      if (
+        saved?.spreadAtLock != null &&
+        live != null &&
+        saved.spreadAtLock !== live
+      ) {
+        count++;
+      }
+    }
+    return count;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    pickType,
+    hasSubmittedBefore,
+    isDirty,
+    savedSelections,
+    existingPickByEventId,
+    oddsByEventId,
+    events,
+  ]);
+  const showTakeLatestBanner = movedPickCount > 0;
+
   return (
     <div className="flex flex-col gap-3 pb-24">
-      <ul className="flex flex-col gap-3">
-        {events.map((event) => {
-          const locked = nowMs >= event.startTime.getTime();
-          const existingPick = existingPickByEventId.get(event.id) ?? null;
-          const selectedTeamId = locked
-            ? (existingPick?.teamId ?? null)
-            : (selections.get(event.id) ?? null);
-          const frozenSpread = locked
-            ? (existingPick?.spreadAtLock ?? null)
-            : null;
-          const pickResult = locked ? (existingPick?.pickResult ?? null) : null;
-          return (
-            <li key={event.id}>
-              <EventPickCard
-                event={event}
-                homeTeam={event.homeTeam}
-                awayTeam={event.awayTeam}
-                odds={oddsByEventId[event.id] ?? null}
-                pickType={pickType}
-                selectedTeamId={selectedTeamId}
-                frozenSpread={frozenSpread}
-                pickResult={pickResult}
-                isLocked={locked}
-                onSelect={
-                  locked ? undefined : (teamId) => togglePick(event.id, teamId)
-                }
-              />
-            </li>
-          );
-        })}
-      </ul>
+      {hasSubmittedBefore ? (
+        <div
+          role="status"
+          className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-700 dark:text-emerald-400"
+        >
+          <Check className="h-4 w-4" aria-hidden />
+          <span>
+            Picks saved
+            {lastSavedAt
+              ? ` · last updated ${formatEasternDateTime(lastSavedAt)}`
+              : ""}
+            {isDirty ? " · unsaved changes" : ""}
+          </span>
+        </div>
+      ) : null}
+      {showTakeLatestBanner ? (
+        <div
+          role="status"
+          className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-800 dark:text-amber-300"
+        >
+          <span className="flex items-center gap-2">
+            <RefreshCw className="h-4 w-4 shrink-0" aria-hidden />
+            {movedPickCount === 1
+              ? "Line moved on 1 of your picks"
+              : `Lines moved on ${movedPickCount} of your picks`}
+          </span>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={isPending}
+            onClick={handleSubmit}
+          >
+            Take latest odds
+          </Button>
+        </div>
+      ) : null}
+      {lockedPickedEvents.length > 0 ? (
+        <section className="flex flex-col gap-2">
+          <h2 className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Locked picks ({lockedPickedEvents.length})
+          </h2>
+          <ul className="flex flex-col gap-3">
+            {lockedPickedEvents.map((event) => {
+              const existingPick = existingPickByEventId.get(event.id) ?? null;
+              return (
+                <li key={event.id}>
+                  <EventPickCard
+                    event={event}
+                    homeTeam={event.homeTeam}
+                    awayTeam={event.awayTeam}
+                    odds={oddsByEventId[event.id] ?? null}
+                    pickType={pickType}
+                    selectedTeamId={existingPick?.teamId ?? null}
+                    frozenSpread={existingPick?.spreadAtLock ?? null}
+                    pickResult={existingPick?.pickResult ?? null}
+                    isLocked
+                  />
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ) : null}
+      {requiredCount === 0 && lockedPickCount > 0 ? (
+        <div
+          role="status"
+          className="rounded-md border border-dashed px-4 py-6 text-center text-sm text-muted-foreground"
+        >
+          All {lockedPickCount} picks locked in for this week.
+        </div>
+      ) : null}
+      {unstartedEvents.length > 0 && requiredCount > 0 ? (
+        <section className="flex flex-col gap-2">
+          {lockedPickedEvents.length > 0 ? (
+            <h2 className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Pick {requiredCount} game{requiredCount === 1 ? "" : "s"}
+            </h2>
+          ) : null}
+          <ul className="flex flex-col gap-3">
+            {unstartedEvents.map((event) => {
+              const existingPick = existingPickByEventId.get(event.id) ?? null;
+              const selectedTeamId = selections.get(event.id) ?? null;
+              // When clean, show the frozen spread on the saved pick. When
+              // dirty, drop the frozen spread so the card falls through to
+              // the live line — that's what will be locked in on
+              // re-submit. Pass the prior frozen spread as a hint when the
+              // selected team matches the saved pick ("was −3.5").
+              const frozenSpread = isDirty
+                ? null
+                : (existingPick?.spreadAtLock ?? null);
+              const priorFrozenSpread =
+                isDirty &&
+                existingPick?.teamId === selectedTeamId &&
+                existingPick?.spreadAtLock != null
+                  ? existingPick.spreadAtLock
+                  : null;
+              return (
+                <li key={event.id}>
+                  <EventPickCard
+                    event={event}
+                    homeTeam={event.homeTeam}
+                    awayTeam={event.awayTeam}
+                    odds={oddsByEventId[event.id] ?? null}
+                    pickType={pickType}
+                    selectedTeamId={selectedTeamId}
+                    frozenSpread={frozenSpread}
+                    priorFrozenSpread={priorFrozenSpread}
+                    pickResult={null}
+                    isLocked={false}
+                    onSelect={(teamId) => togglePick(event.id, teamId)}
+                  />
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ) : null}
       {requiredCount > 0 ? (
         <div className="fixed inset-x-0 bottom-0 z-20 border-t border-border bg-background/95 backdrop-blur">
-          <div className="mx-auto flex w-full max-w-4xl items-center justify-between gap-3 px-4 py-3">
-            <span className="text-sm text-muted-foreground">
-              {lockedEvents.length > 0
-                ? `${picksMade}/${requiredCount} picks (${lockedEvents.length} game${lockedEvents.length === 1 ? "" : "s"} locked)`
-                : `${picksMade}/${requiredCount} picks`}
-            </span>
-            <Button
-              type="button"
-              size="lg"
-              disabled={!canSubmit || isPending}
-              onClick={handleSubmit}
-            >
-              {isPending
-                ? "Submitting…"
-                : `Submit Picks (${picksMade}/${requiredCount})`}
-            </Button>
+          <div className="mx-auto flex w-full max-w-4xl flex-col gap-0">
+            {showAtsRefreshBanner ? (
+              <div className="flex items-start gap-2 border-b border-amber-500/30 bg-amber-500/10 px-4 py-2 text-xs text-amber-800 dark:text-amber-300">
+                <AlertTriangle
+                  className="mt-0.5 h-4 w-4 shrink-0"
+                  aria-hidden
+                />
+                <span>
+                  Re-submitting locks in the current spreads on all picks — not
+                  just the ones you changed.
+                </span>
+              </div>
+            ) : null}
+            <div className="flex items-center justify-between gap-3 px-4 py-3">
+              <div className="flex min-w-0 items-center gap-2">
+                {canReset ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    disabled={isPending}
+                    onClick={handleReset}
+                  >
+                    {resetLabel}
+                  </Button>
+                ) : null}
+                <span className="truncate text-sm text-muted-foreground">
+                  {lockedPickCount > 0
+                    ? `${picksMade}/${requiredCount} picks (${lockedPickCount} locked)`
+                    : `${picksMade}/${requiredCount} picks`}
+                </span>
+              </div>
+              <Button
+                type="button"
+                size="lg"
+                disabled={!canSubmit || isPending}
+                onClick={handleSubmit}
+              >
+                {isPending
+                  ? "Submitting…"
+                  : !hasSubmittedBefore
+                    ? `Submit Picks (${picksMade}/${requiredCount})`
+                    : isDirty
+                      ? `Update Picks (${picksMade}/${requiredCount})`
+                      : "Saved ✓"}
+              </Button>
+            </div>
           </div>
         </div>
       ) : null}

--- a/components/picks/submit-picks-form.tsx
+++ b/components/picks/submit-picks-form.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useMemo, useState, useTransition } from "react";
+import { toast } from "sonner";
+
+import { submitPicksAction } from "@/actions/picks";
+import { EventPickCard } from "@/components/picks/event-pick-card";
+import { Button } from "@/components/ui/button";
+import type { EventWithTeams, OddsWithSportsbookName } from "@/data/events";
+import type { PickType } from "@/lib/db/schema/leagues";
+import type { Pick } from "@/lib/db/schema/picks";
+
+export function SubmitPicksForm({
+  leagueId,
+  phaseId,
+  events,
+  oddsByEventId,
+  pickType,
+  existingPicks,
+  picksPerPhase,
+  nowMs,
+}: {
+  leagueId: string;
+  phaseId: string;
+  events: EventWithTeams[];
+  oddsByEventId: Record<string, OddsWithSportsbookName>;
+  pickType: PickType;
+  existingPicks: Pick[];
+  picksPerPhase: number;
+  nowMs: number;
+}) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const unstartedEvents = useMemo(
+    () => events.filter((e) => nowMs < e.startTime.getTime()),
+    [events, nowMs],
+  );
+  const lockedEvents = useMemo(
+    () => events.filter((e) => nowMs >= e.startTime.getTime()),
+    [events, nowMs],
+  );
+  const requiredCount = Math.min(picksPerPhase, unstartedEvents.length);
+
+  const existingPickByEventId = useMemo(
+    () => new Map(existingPicks.map((p) => [p.eventId, p])),
+    [existingPicks],
+  );
+
+  const [selections, setSelections] = useState<Map<string, string>>(() => {
+    const initial = new Map<string, string>();
+    for (const event of unstartedEvents) {
+      const prior = existingPickByEventId.get(event.id);
+      if (prior) initial.set(event.id, prior.teamId);
+    }
+    return initial;
+  });
+
+  function togglePick(eventId: string, teamId: string): void {
+    setSelections((prev) => {
+      const next = new Map(prev);
+      const current = next.get(eventId);
+      if (current === teamId) {
+        next.delete(eventId);
+        return next;
+      }
+      if (!next.has(eventId) && next.size >= requiredCount) {
+        toast.error(
+          `You can only pick ${requiredCount} game${requiredCount === 1 ? "" : "s"} — deselect one first.`,
+        );
+        return prev;
+      }
+      next.set(eventId, teamId);
+      return next;
+    });
+  }
+
+  const picksMade = selections.size;
+  const canSubmit = picksMade === requiredCount && requiredCount > 0;
+
+  function handleSubmit(): void {
+    const picks = Array.from(selections.entries()).map(([eventId, teamId]) => ({
+      eventId,
+      teamId,
+    }));
+    startTransition(async () => {
+      const result = await submitPicksAction({ leagueId, phaseId, picks });
+      if (!result.success) {
+        toast.error(result.error);
+        return;
+      }
+      toast.success("Picks saved");
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-3 pb-24">
+      <ul className="flex flex-col gap-3">
+        {events.map((event) => {
+          const locked = nowMs >= event.startTime.getTime();
+          const existingPick = existingPickByEventId.get(event.id) ?? null;
+          const selectedTeamId = locked
+            ? (existingPick?.teamId ?? null)
+            : (selections.get(event.id) ?? null);
+          const frozenSpread = locked
+            ? (existingPick?.spreadAtLock ?? null)
+            : null;
+          const pickResult = locked ? (existingPick?.pickResult ?? null) : null;
+          return (
+            <li key={event.id}>
+              <EventPickCard
+                event={event}
+                homeTeam={event.homeTeam}
+                awayTeam={event.awayTeam}
+                odds={oddsByEventId[event.id] ?? null}
+                pickType={pickType}
+                selectedTeamId={selectedTeamId}
+                frozenSpread={frozenSpread}
+                pickResult={pickResult}
+                isLocked={locked}
+                onSelect={
+                  locked ? undefined : (teamId) => togglePick(event.id, teamId)
+                }
+              />
+            </li>
+          );
+        })}
+      </ul>
+      {requiredCount > 0 ? (
+        <div className="fixed inset-x-0 bottom-0 z-20 border-t border-border bg-background/95 backdrop-blur">
+          <div className="mx-auto flex w-full max-w-4xl items-center justify-between gap-3 px-4 py-3">
+            <span className="text-sm text-muted-foreground">
+              {lockedEvents.length > 0
+                ? `${picksMade}/${requiredCount} picks (${lockedEvents.length} game${lockedEvents.length === 1 ? "" : "s"} locked)`
+                : `${picksMade}/${requiredCount} picks`}
+            </span>
+            <Button
+              type="button"
+              size="lg"
+              disabled={!canSubmit || isPending}
+              onClick={handleSubmit}
+            >
+              {isPending
+                ? "Submitting…"
+                : `Submit Picks (${picksMade}/${requiredCount})`}
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/data/events.ts
+++ b/data/events.ts
@@ -259,6 +259,24 @@ export interface OddsWithSportsbookName extends Odds {
   sportsbookName: string;
 }
 
+/**
+ * Dedupe the sportsbook-ordered output of `getOddsForEventsWithSportsbook`
+ * so each event maps to one primary row. The data function orders by
+ * sportsbook name ASC, so this keeps the alphabetically-first sportsbook
+ * per event — stable and deterministic.
+ */
+export function indexPrimaryOddsByEvent(
+  rows: OddsWithSportsbookName[],
+): Map<string, OddsWithSportsbookName> {
+  const map = new Map<string, OddsWithSportsbookName>();
+  for (const row of rows) {
+    if (!map.has(row.eventId)) {
+      map.set(row.eventId, row);
+    }
+  }
+  return map;
+}
+
 export async function getOddsForEventsWithSportsbook(
   eventIds: string[],
   tx?: Transaction,

--- a/data/events.ts
+++ b/data/events.ts
@@ -12,7 +12,7 @@ import type {
   Sportsbook,
   Team,
 } from "@/lib/db/schema/sports";
-import { events, odds, phases } from "@/lib/db/schema/sports";
+import { events, odds, phases, sportsbooks } from "@/lib/db/schema/sports";
 import { externalEvents } from "@/lib/db/schema/external";
 
 export async function insertEvent(
@@ -253,6 +253,38 @@ export async function getLockedEventIds(
 export interface OddsWithContext extends Odds {
   sportsbook: Sportsbook;
   event: EventWithTeams;
+}
+
+export interface OddsWithSportsbookName extends Odds {
+  sportsbookName: string;
+}
+
+export async function getOddsForEventsWithSportsbook(
+  eventIds: string[],
+  tx?: Transaction,
+): Promise<OddsWithSportsbookName[]> {
+  if (eventIds.length === 0) return [];
+  const client = tx ?? db;
+  const rows = await client
+    .select({
+      id: odds.id,
+      eventId: odds.eventId,
+      sportsbookId: odds.sportsbookId,
+      homeSpread: odds.homeSpread,
+      awaySpread: odds.awaySpread,
+      homeMoneyline: odds.homeMoneyline,
+      awayMoneyline: odds.awayMoneyline,
+      overUnder: odds.overUnder,
+      lockedAt: odds.lockedAt,
+      createdAt: odds.createdAt,
+      updatedAt: odds.updatedAt,
+      sportsbookName: sportsbooks.name,
+    })
+    .from(odds)
+    .innerJoin(sportsbooks, eq(odds.sportsbookId, sportsbooks.id))
+    .where(inArray(odds.eventId, eventIds))
+    .orderBy(asc(sportsbooks.name));
+  return rows;
 }
 
 export async function getOddsByPhaseWithContext(

--- a/data/phases.ts
+++ b/data/phases.ts
@@ -57,6 +57,17 @@ export async function getPhasesBySeason(
     .orderBy(asc(phases.startDate));
 }
 
+export async function getPhaseById(
+  phaseId: string,
+  tx?: Transaction,
+): Promise<Phase | null> {
+  const client = tx ?? db;
+  const result = await client.query.phases.findFirst({
+    where: eq(phases.id, phaseId),
+  });
+  return result ?? null;
+}
+
 export async function setLockedPhase(
   phaseId: string,
   lockedAt: Date,

--- a/data/picks.ts
+++ b/data/picks.ts
@@ -1,0 +1,26 @@
+import { and, asc, eq } from "drizzle-orm";
+
+import type { Transaction } from "@/data/utils";
+import { db } from "@/lib/db";
+import type { Pick } from "@/lib/db/schema/picks";
+import { picks } from "@/lib/db/schema/picks";
+
+export async function getPicksForLeaguePhase(
+  leagueId: string,
+  userId: string,
+  phaseId: string,
+  tx?: Transaction,
+): Promise<Pick[]> {
+  const client = tx ?? db;
+  return client
+    .select()
+    .from(picks)
+    .where(
+      and(
+        eq(picks.leagueId, leagueId),
+        eq(picks.userId, userId),
+        eq(picks.phaseId, phaseId),
+      ),
+    )
+    .orderBy(asc(picks.createdAt));
+}

--- a/data/picks.ts
+++ b/data/picks.ts
@@ -1,9 +1,11 @@
-import { and, asc, eq, inArray } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull } from "drizzle-orm";
 
 import type { Transaction } from "@/data/utils";
 import { db } from "@/lib/db";
-import type { NewPick, Pick } from "@/lib/db/schema/picks";
+import type { NewPick, Pick, PickResult } from "@/lib/db/schema/picks";
 import { picks } from "@/lib/db/schema/picks";
+import type { Event } from "@/lib/db/schema/sports";
+import { events, phases } from "@/lib/db/schema/sports";
 
 export async function getPicksForLeaguePhase(
   leagueId: string,
@@ -51,4 +53,100 @@ export async function deleteUserPicksForEvents(
         inArray(picks.eventId, eventIds),
       ),
     );
+}
+
+export interface PickWithEvent {
+  pick: Pick;
+  event: Event;
+}
+
+export async function getPicksForLeagueSeasonWithEvent(
+  leagueId: string,
+  seasonId: string,
+  tx?: Transaction,
+): Promise<PickWithEvent[]> {
+  const client = tx ?? db;
+  const rows = await client
+    .select({ pick: picks, event: events })
+    .from(picks)
+    .innerJoin(events, eq(picks.eventId, events.id))
+    .innerJoin(phases, eq(picks.phaseId, phases.id))
+    .where(and(eq(picks.leagueId, leagueId), eq(phases.seasonId, seasonId)));
+  return rows;
+}
+
+export interface PickResultUpdate {
+  id: string;
+  pickResult: PickResult | null;
+}
+
+export async function updatePickResults(
+  updates: PickResultUpdate[],
+  tx?: Transaction,
+): Promise<void> {
+  if (updates.length === 0) return;
+  const client = tx ?? db;
+  // Batch update via one statement per distinct target value (at most 4:
+  // win/loss/push/null). Each runs against the subset of ids with that
+  // target — still one round trip per bucket, not per pick.
+  const byTarget = new Map<PickResult | null, string[]>();
+  for (const update of updates) {
+    const bucket = byTarget.get(update.pickResult) ?? [];
+    bucket.push(update.id);
+    byTarget.set(update.pickResult, bucket);
+  }
+  for (const [result, ids] of byTarget) {
+    await client
+      .update(picks)
+      .set({ pickResult: result, updatedAt: new Date() })
+      .where(inArray(picks.id, ids));
+  }
+}
+
+export async function clearPickResultsForEvent(
+  eventId: string,
+  tx?: Transaction,
+): Promise<void> {
+  const client = tx ?? db;
+  await client
+    .update(picks)
+    .set({ pickResult: null, updatedAt: new Date() })
+    .where(eq(picks.eventId, eventId));
+}
+
+export interface LeagueSeasonPair {
+  leagueId: string;
+  seasonId: string;
+}
+
+export async function getLeagueSeasonPairsForEvent(
+  eventId: string,
+  tx?: Transaction,
+): Promise<LeagueSeasonPair[]> {
+  const client = tx ?? db;
+  const rows = await client
+    .selectDistinct({
+      leagueId: picks.leagueId,
+      seasonId: phases.seasonId,
+    })
+    .from(picks)
+    .innerJoin(phases, eq(picks.phaseId, phases.id))
+    .where(eq(picks.eventId, eventId));
+  return rows;
+}
+
+export async function getLeagueSeasonPairsWithUnscoredFinalPicks(
+  tx?: Transaction,
+): Promise<LeagueSeasonPair[]> {
+  const client = tx ?? db;
+  const rows = await client
+    .selectDistinct({
+      leagueId: picks.leagueId,
+      seasonId: phases.seasonId,
+    })
+    .from(picks)
+    .innerJoin(events, eq(picks.eventId, events.id))
+    .innerJoin(phases, eq(picks.phaseId, phases.id))
+    .where(and(isNull(picks.pickResult), eq(events.status, "final")));
+  return rows;
 }

--- a/data/picks.ts
+++ b/data/picks.ts
@@ -27,6 +27,19 @@ export async function getPicksForLeaguePhase(
     .orderBy(asc(picks.createdAt));
 }
 
+export async function getPicksForLeaguePhaseAllMembers(
+  leagueId: string,
+  phaseId: string,
+  tx?: Transaction,
+): Promise<Pick[]> {
+  const client = tx ?? db;
+  return client
+    .select()
+    .from(picks)
+    .where(and(eq(picks.leagueId, leagueId), eq(picks.phaseId, phaseId)))
+    .orderBy(asc(picks.userId), asc(picks.createdAt));
+}
+
 export async function insertPicks(
   data: Omit<NewPick, "id" | "createdAt" | "updatedAt">[],
   tx?: Transaction,

--- a/data/picks.ts
+++ b/data/picks.ts
@@ -1,8 +1,8 @@
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, eq, inArray } from "drizzle-orm";
 
 import type { Transaction } from "@/data/utils";
 import { db } from "@/lib/db";
-import type { Pick } from "@/lib/db/schema/picks";
+import type { NewPick, Pick } from "@/lib/db/schema/picks";
 import { picks } from "@/lib/db/schema/picks";
 
 export async function getPicksForLeaguePhase(
@@ -23,4 +23,32 @@ export async function getPicksForLeaguePhase(
       ),
     )
     .orderBy(asc(picks.createdAt));
+}
+
+export async function insertPicks(
+  data: Omit<NewPick, "id" | "createdAt" | "updatedAt">[],
+  tx?: Transaction,
+): Promise<Pick[]> {
+  if (data.length === 0) return [];
+  const client = tx ?? db;
+  return client.insert(picks).values(data).returning();
+}
+
+export async function deleteUserPicksForEvents(
+  leagueId: string,
+  userId: string,
+  eventIds: string[],
+  tx?: Transaction,
+): Promise<void> {
+  if (eventIds.length === 0) return;
+  const client = tx ?? db;
+  await client
+    .delete(picks)
+    .where(
+      and(
+        eq(picks.leagueId, leagueId),
+        eq(picks.userId, userId),
+        inArray(picks.eventId, eventIds),
+      ),
+    );
 }

--- a/data/standings.ts
+++ b/data/standings.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 
 import type { Transaction } from "@/data/utils";
 import { db } from "@/lib/db";
@@ -7,6 +7,10 @@ import type {
   NewLeagueStanding,
 } from "@/lib/db/schema/leagues";
 import { leagueStandings } from "@/lib/db/schema/leagues";
+import { profile } from "@/lib/db/schema/profiles";
+import type { Profile } from "@/lib/db/schema/profiles";
+import type { Season } from "@/lib/db/schema/sports";
+import { seasons } from "@/lib/db/schema/sports";
 
 export async function insertLeagueStanding(
   data: Omit<NewLeagueStanding, "id" | "createdAt" | "updatedAt">,
@@ -51,6 +55,44 @@ export async function removeLeagueStandingsForUser(
         eq(leagueStandings.userId, userId),
       ),
     );
+}
+
+export interface LeagueStandingWithProfile extends LeagueStanding {
+  profile: Profile;
+}
+
+export async function getStandingsForLeagueSeasonWithProfiles(
+  leagueId: string,
+  seasonId: string,
+  tx?: Transaction,
+): Promise<LeagueStandingWithProfile[]> {
+  const client = tx ?? db;
+  const rows = await client
+    .select({ standing: leagueStandings, profile })
+    .from(leagueStandings)
+    .innerJoin(profile, eq(leagueStandings.userId, profile.userId))
+    .where(
+      and(
+        eq(leagueStandings.leagueId, leagueId),
+        eq(leagueStandings.seasonId, seasonId),
+      ),
+    )
+    .orderBy(asc(leagueStandings.rank), asc(profile.username));
+  return rows.map((row) => ({ ...row.standing, profile: row.profile }));
+}
+
+export async function getSeasonsWithStandingsForLeague(
+  leagueId: string,
+  tx?: Transaction,
+): Promise<Season[]> {
+  const client = tx ?? db;
+  const rows = await client
+    .selectDistinct({ season: seasons })
+    .from(leagueStandings)
+    .innerJoin(seasons, eq(leagueStandings.seasonId, seasons.id))
+    .where(eq(leagueStandings.leagueId, leagueId))
+    .orderBy(asc(seasons.year));
+  return rows.map((row) => row.season);
 }
 
 export async function upsertLeagueStanding(

--- a/data/standings.ts
+++ b/data/standings.ts
@@ -52,3 +52,30 @@ export async function removeLeagueStandingsForUser(
       ),
     );
 }
+
+export async function upsertLeagueStanding(
+  data: Omit<NewLeagueStanding, "id" | "createdAt" | "updatedAt">,
+  tx?: Transaction,
+): Promise<LeagueStanding> {
+  const client = tx ?? db;
+  const [result] = await client
+    .insert(leagueStandings)
+    .values(data)
+    .onConflictDoUpdate({
+      target: [
+        leagueStandings.leagueId,
+        leagueStandings.userId,
+        leagueStandings.seasonId,
+      ],
+      set: {
+        wins: data.wins ?? 0,
+        losses: data.losses ?? 0,
+        pushes: data.pushes ?? 0,
+        points: data.points ?? 0,
+        rank: data.rank ?? 1,
+        updatedAt: new Date(),
+      },
+    })
+    .returning();
+  return result;
+}

--- a/docs/BUSINESS_SPEC.md
+++ b/docs/BUSINESS_SPEC.md
@@ -284,7 +284,10 @@ When a user views their league, the system determines the "current phase":
 
 ### 6.4 Phase Navigation
 
-Users can browse to previous and future phases using prev/next navigation. This allows viewing historical picks and results.
+Users can browse to previous and future phases using prev/next navigation. Both are **view-only**:
+
+- **Past phases** show locked picks and scored results.
+- **Future phases** show their game schedule (and odds, if synced) but **do not accept pick submissions** — the submit form is hidden and the action rejects any attempt. Users pick one week at a time, for the current phase only. This avoids carrying forward a pick made against a line that moves, and avoids asking users to commit to games before odds stabilize.
 
 ### 6.5 Excluded Phases
 
@@ -300,9 +303,9 @@ Users can browse to previous and future phases using prev/next navigation. This 
 All of the following must be true for picks to be accepted:
 
 1. The user **is a member** of the league.
-2. Picks are for the **current phase only** — users cannot submit picks for past or future phases.
+2. Picks are for the **current phase only** — users cannot submit picks for past or future phases. The current phase is the one §6.3 resolves to; all other phases in the league's range are view-only (§6.4). Attempting to submit picks against a non-current phaseId is rejected.
 3. The phase's **pick lock time has not passed**.
-4. The user must submit picks for **exactly** `min(league's picks-per-phase setting, number of games that haven't started yet this phase)` games.
+4. The user must submit picks for **exactly** `min(picksPerPhase − lockedPickCount, unstartedEvents)` games, where `lockedPickCount` is the number of picks the user already has on games that have started this phase. The league's `picksPerPhase` setting is the total per-phase budget — picks locked in on earlier games (e.g. Thursday Night Football) consume that budget, so a re-submission only asks for the remaining quota. When the budget is exhausted, no further picks can be submitted for the phase even if unstarted games remain.
 5. No **duplicate games** — each game can only be picked once per submission.
 6. Every picked game must be in the current phase and must **not have started yet**.
 7. The selected team must be a valid participant (home or away) in the corresponding game.

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -4,6 +4,7 @@ import { drizzle as drizzlePg } from "drizzle-orm/node-postgres";
 import * as authSchema from "./schema/auth";
 import * as externalSchema from "./schema/external";
 import * as leaguesSchema from "./schema/leagues";
+import * as picksSchema from "./schema/picks";
 import * as profilesSchema from "./schema/profiles";
 import * as relationsSchema from "./schema/relations";
 import * as simulatorSchema from "./schema/simulator";
@@ -13,6 +14,7 @@ const schema = {
   ...authSchema,
   ...externalSchema,
   ...leaguesSchema,
+  ...picksSchema,
   ...profilesSchema,
   ...relationsSchema,
   ...simulatorSchema,

--- a/lib/db/migrations/0009_picks_table.sql
+++ b/lib/db/migrations/0009_picks_table.sql
@@ -1,0 +1,23 @@
+CREATE TYPE "public"."pick_result" AS ENUM('win', 'loss', 'push');--> statement-breakpoint
+CREATE TABLE "picks" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"league_id" uuid NOT NULL,
+	"user_id" text NOT NULL,
+	"phase_id" uuid NOT NULL,
+	"event_id" uuid NOT NULL,
+	"team_id" uuid NOT NULL,
+	"spread_at_lock" double precision,
+	"pick_result" "pick_result",
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "picks_league_user_event_uniq" UNIQUE("league_id","user_id","event_id")
+);
+--> statement-breakpoint
+ALTER TABLE "picks" ADD CONSTRAINT "picks_league_id_leagues_id_fk" FOREIGN KEY ("league_id") REFERENCES "public"."leagues"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "picks" ADD CONSTRAINT "picks_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "picks" ADD CONSTRAINT "picks_phase_id_phases_id_fk" FOREIGN KEY ("phase_id") REFERENCES "public"."phases"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "picks" ADD CONSTRAINT "picks_event_id_events_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."events"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "picks" ADD CONSTRAINT "picks_team_id_teams_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "picks_league_user_idx" ON "picks" USING btree ("league_id","user_id");--> statement-breakpoint
+CREATE INDEX "picks_phase_id_idx" ON "picks" USING btree ("phase_id");--> statement-breakpoint
+CREATE INDEX "picks_event_id_idx" ON "picks" USING btree ("event_id");

--- a/lib/db/migrations/meta/0009_snapshot.json
+++ b/lib/db/migrations/meta/0009_snapshot.json
@@ -1,0 +1,2526 @@
+{
+  "id": "210657cf-ac15-4679-bd46-a2ab0413d2bd",
+  "prevId": "2fae6b9d-4d5f-4ea3-9b32-0b21a3b2d4e1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_events": {
+      "name": "external_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "odds_ref": {
+          "name": "odds_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_ref": {
+          "name": "status_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_score_ref": {
+          "name": "home_score_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "away_score_ref": {
+          "name": "away_score_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_events_event_id_idx": {
+          "name": "external_events_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_events_data_source_id_data_sources_id_fk": {
+          "name": "external_events_data_source_id_data_sources_id_fk",
+          "tableFrom": "external_events",
+          "tableTo": "data_sources",
+          "columnsFrom": ["data_source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_events_event_id_events_id_fk": {
+          "name": "external_events_event_id_events_id_fk",
+          "tableFrom": "external_events",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "external_events_source_ext_uniq": {
+          "name": "external_events_source_ext_uniq",
+          "nullsNotDistinct": false,
+          "columns": ["data_source_id", "external_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_phases": {
+      "name": "external_phases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase_id": {
+          "name": "phase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_phases_phase_id_idx": {
+          "name": "external_phases_phase_id_idx",
+          "columns": [
+            {
+              "expression": "phase_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_phases_data_source_id_data_sources_id_fk": {
+          "name": "external_phases_data_source_id_data_sources_id_fk",
+          "tableFrom": "external_phases",
+          "tableTo": "data_sources",
+          "columnsFrom": ["data_source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_phases_phase_id_phases_id_fk": {
+          "name": "external_phases_phase_id_phases_id_fk",
+          "tableFrom": "external_phases",
+          "tableTo": "phases",
+          "columnsFrom": ["phase_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "external_phases_source_ext_uniq": {
+          "name": "external_phases_source_ext_uniq",
+          "nullsNotDistinct": false,
+          "columns": ["data_source_id", "external_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_seasons": {
+      "name": "external_seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_seasons_season_id_idx": {
+          "name": "external_seasons_season_id_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_seasons_data_source_id_data_sources_id_fk": {
+          "name": "external_seasons_data_source_id_data_sources_id_fk",
+          "tableFrom": "external_seasons",
+          "tableTo": "data_sources",
+          "columnsFrom": ["data_source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_seasons_season_id_seasons_id_fk": {
+          "name": "external_seasons_season_id_seasons_id_fk",
+          "tableFrom": "external_seasons",
+          "tableTo": "seasons",
+          "columnsFrom": ["season_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "external_seasons_source_ext_uniq": {
+          "name": "external_seasons_source_ext_uniq",
+          "nullsNotDistinct": false,
+          "columns": ["data_source_id", "external_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_sportsbooks": {
+      "name": "external_sportsbooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sportsbook_id": {
+          "name": "sportsbook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_sportsbooks_sportsbook_id_idx": {
+          "name": "external_sportsbooks_sportsbook_id_idx",
+          "columns": [
+            {
+              "expression": "sportsbook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_sportsbooks_data_source_id_data_sources_id_fk": {
+          "name": "external_sportsbooks_data_source_id_data_sources_id_fk",
+          "tableFrom": "external_sportsbooks",
+          "tableTo": "data_sources",
+          "columnsFrom": ["data_source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_sportsbooks_sportsbook_id_sportsbooks_id_fk": {
+          "name": "external_sportsbooks_sportsbook_id_sportsbooks_id_fk",
+          "tableFrom": "external_sportsbooks",
+          "tableTo": "sportsbooks",
+          "columnsFrom": ["sportsbook_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "external_sportsbooks_source_ext_uniq": {
+          "name": "external_sportsbooks_source_ext_uniq",
+          "nullsNotDistinct": false,
+          "columns": ["data_source_id", "external_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_teams": {
+      "name": "external_teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_teams_team_id_idx": {
+          "name": "external_teams_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_teams_data_source_id_data_sources_id_fk": {
+          "name": "external_teams_data_source_id_data_sources_id_fk",
+          "tableFrom": "external_teams",
+          "tableTo": "data_sources",
+          "columnsFrom": ["data_source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_teams_team_id_teams_id_fk": {
+          "name": "external_teams_team_id_teams_id_fk",
+          "tableFrom": "external_teams",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "external_teams_source_ext_uniq": {
+          "name": "external_teams_source_ext_uniq",
+          "nullsNotDistinct": false,
+          "columns": ["data_source_id", "external_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.direct_invites": {
+      "name": "direct_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_user_id": {
+          "name": "invitee_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_user_id": {
+          "name": "inviter_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "league_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "direct_invites_invitee_user_id_idx": {
+          "name": "direct_invites_invitee_user_id_idx",
+          "columns": [
+            {
+              "expression": "invitee_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_invites_league_id_idx": {
+          "name": "direct_invites_league_id_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "direct_invites_league_id_leagues_id_fk": {
+          "name": "direct_invites_league_id_leagues_id_fk",
+          "tableFrom": "direct_invites",
+          "tableTo": "leagues",
+          "columnsFrom": ["league_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_invites_invitee_user_id_user_id_fk": {
+          "name": "direct_invites_invitee_user_id_user_id_fk",
+          "tableFrom": "direct_invites",
+          "tableTo": "user",
+          "columnsFrom": ["invitee_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_invites_inviter_user_id_user_id_fk": {
+          "name": "direct_invites_inviter_user_id_user_id_fk",
+          "tableFrom": "direct_invites",
+          "tableTo": "user",
+          "columnsFrom": ["inviter_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "direct_invites_league_invitee_uniq": {
+          "name": "direct_invites_league_invitee_uniq",
+          "nullsNotDistinct": false,
+          "columns": ["league_id", "invitee_user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.league_members": {
+      "name": "league_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "league_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "league_members_user_id_idx": {
+          "name": "league_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "league_members_league_id_idx": {
+          "name": "league_members_league_id_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "league_members_league_id_leagues_id_fk": {
+          "name": "league_members_league_id_leagues_id_fk",
+          "tableFrom": "league_members",
+          "tableTo": "leagues",
+          "columnsFrom": ["league_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "league_members_user_id_user_id_fk": {
+          "name": "league_members_user_id_user_id_fk",
+          "tableFrom": "league_members",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "league_members_league_user_uniq": {
+          "name": "league_members_league_user_uniq",
+          "nullsNotDistinct": false,
+          "columns": ["league_id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.league_standings": {
+      "name": "league_standings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "losses": {
+          "name": "losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pushes": {
+          "name": "pushes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "points": {
+          "name": "points",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "league_standings_league_season_idx": {
+          "name": "league_standings_league_season_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "league_standings_league_id_leagues_id_fk": {
+          "name": "league_standings_league_id_leagues_id_fk",
+          "tableFrom": "league_standings",
+          "tableTo": "leagues",
+          "columnsFrom": ["league_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "league_standings_user_id_user_id_fk": {
+          "name": "league_standings_user_id_user_id_fk",
+          "tableFrom": "league_standings",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "league_standings_season_id_seasons_id_fk": {
+          "name": "league_standings_season_id_seasons_id_fk",
+          "tableFrom": "league_standings",
+          "tableTo": "seasons",
+          "columnsFrom": ["season_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "league_standings_league_user_season_uniq": {
+          "name": "league_standings_league_user_season_uniq",
+          "nullsNotDistinct": false,
+          "columns": ["league_id", "user_id", "season_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.leagues": {
+      "name": "leagues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sports_league_id": {
+          "name": "sports_league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_season_type": {
+          "name": "start_season_type",
+          "type": "season_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_week_number": {
+          "name": "start_week_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_season_type": {
+          "name": "end_season_type",
+          "type": "season_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_week_number": {
+          "name": "end_week_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picks_per_phase": {
+          "name": "picks_per_phase",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_type": {
+          "name": "pick_type",
+          "type": "pick_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "leagues_sports_league_id_idx": {
+          "name": "leagues_sports_league_id_idx",
+          "columns": [
+            {
+              "expression": "sports_league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "leagues_sports_league_id_sports_leagues_id_fk": {
+          "name": "leagues_sports_league_id_sports_leagues_id_fk",
+          "tableFrom": "leagues",
+          "tableTo": "sports_leagues",
+          "columnsFrom": ["sports_league_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.link_invites": {
+      "name": "link_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_user_id": {
+          "name": "inviter_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "league_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "link_invites_league_id_idx": {
+          "name": "link_invites_league_id_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "link_invites_league_id_leagues_id_fk": {
+          "name": "link_invites_league_id_leagues_id_fk",
+          "tableFrom": "link_invites",
+          "tableTo": "leagues",
+          "columnsFrom": ["league_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "link_invites_inviter_user_id_user_id_fk": {
+          "name": "link_invites_inviter_user_id_user_id_fk",
+          "tableFrom": "link_invites",
+          "tableTo": "user",
+          "columnsFrom": ["inviter_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "link_invites_token_unique": {
+          "name": "link_invites_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.picks": {
+      "name": "picks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase_id": {
+          "name": "phase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spread_at_lock": {
+          "name": "spread_at_lock",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pick_result": {
+          "name": "pick_result",
+          "type": "pick_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "picks_league_user_idx": {
+          "name": "picks_league_user_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "picks_phase_id_idx": {
+          "name": "picks_phase_id_idx",
+          "columns": [
+            {
+              "expression": "phase_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "picks_event_id_idx": {
+          "name": "picks_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "picks_league_id_leagues_id_fk": {
+          "name": "picks_league_id_leagues_id_fk",
+          "tableFrom": "picks",
+          "tableTo": "leagues",
+          "columnsFrom": ["league_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "picks_user_id_user_id_fk": {
+          "name": "picks_user_id_user_id_fk",
+          "tableFrom": "picks",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "picks_phase_id_phases_id_fk": {
+          "name": "picks_phase_id_phases_id_fk",
+          "tableFrom": "picks",
+          "tableTo": "phases",
+          "columnsFrom": ["phase_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "picks_event_id_events_id_fk": {
+          "name": "picks_event_id_events_id_fk",
+          "tableFrom": "picks",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "picks_team_id_teams_id_fk": {
+          "name": "picks_team_id_teams_id_fk",
+          "tableFrom": "picks",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "picks_league_user_event_uniq": {
+          "name": "picks_league_user_event_uniq",
+          "nullsNotDistinct": false,
+          "columns": ["league_id", "user_id", "event_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "profile_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "setup_complete": {
+          "name": "setup_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_user_id_user_id_fk": {
+          "name": "profile_user_id_user_id_fk",
+          "tableFrom": "profile",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_user_id_unique": {
+          "name": "profile_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        },
+        "profile_username_unique": {
+          "name": "profile_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulator_state": {
+      "name": "simulator_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "season_year": {
+          "name": "season_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sim_now": {
+          "name": "sim_now",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initialized": {
+          "name": "initialized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulator_state_singleton_unique": {
+          "name": "simulator_state_singleton_unique",
+          "nullsNotDistinct": false,
+          "columns": ["singleton"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_sources": {
+      "name": "data_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "data_sources_name_unique": {
+          "name": "data_sources_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phase_id": {
+          "name": "phase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_team_id": {
+          "name": "home_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "away_team_id": {
+          "name": "away_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "home_score": {
+          "name": "home_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "away_score": {
+          "name": "away_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_phase_id_idx": {
+          "name": "events_phase_id_idx",
+          "columns": [
+            {
+              "expression": "phase_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_home_team_id_idx": {
+          "name": "events_home_team_id_idx",
+          "columns": [
+            {
+              "expression": "home_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_away_team_id_idx": {
+          "name": "events_away_team_id_idx",
+          "columns": [
+            {
+              "expression": "away_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_phase_id_phases_id_fk": {
+          "name": "events_phase_id_phases_id_fk",
+          "tableFrom": "events",
+          "tableTo": "phases",
+          "columnsFrom": ["phase_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_home_team_id_teams_id_fk": {
+          "name": "events_home_team_id_teams_id_fk",
+          "tableFrom": "events",
+          "tableTo": "teams",
+          "columnsFrom": ["home_team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "events_away_team_id_teams_id_fk": {
+          "name": "events_away_team_id_teams_id_fk",
+          "tableFrom": "events",
+          "tableTo": "teams",
+          "columnsFrom": ["away_team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.odds": {
+      "name": "odds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sportsbook_id": {
+          "name": "sportsbook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_spread": {
+          "name": "home_spread",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "away_spread": {
+          "name": "away_spread",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_moneyline": {
+          "name": "home_moneyline",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "away_moneyline": {
+          "name": "away_moneyline",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "over_under": {
+          "name": "over_under",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "odds_event_id_idx": {
+          "name": "odds_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "odds_event_id_events_id_fk": {
+          "name": "odds_event_id_events_id_fk",
+          "tableFrom": "odds",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "odds_sportsbook_id_sportsbooks_id_fk": {
+          "name": "odds_sportsbook_id_sportsbooks_id_fk",
+          "tableFrom": "odds",
+          "tableTo": "sportsbooks",
+          "columnsFrom": ["sportsbook_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "odds_event_sportsbook_uniq": {
+          "name": "odds_event_sportsbook_uniq",
+          "nullsNotDistinct": false,
+          "columns": ["event_id", "sportsbook_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.phases": {
+      "name": "phases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_type": {
+          "name": "season_type",
+          "type": "season_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_number": {
+          "name": "week_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_lock_time": {
+          "name": "pick_lock_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "phases_season_id_idx": {
+          "name": "phases_season_id_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phases_season_id_seasons_id_fk": {
+          "name": "phases_season_id_seasons_id_fk",
+          "tableFrom": "phases",
+          "tableTo": "seasons",
+          "columnsFrom": ["season_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "phases_season_type_week_uniq": {
+          "name": "phases_season_type_week_uniq",
+          "nullsNotDistinct": false,
+          "columns": ["season_id", "season_type", "week_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sports_league_id": {
+          "name": "sports_league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "seasons_sports_league_id_idx": {
+          "name": "seasons_sports_league_id_idx",
+          "columns": [
+            {
+              "expression": "sports_league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "seasons_sports_league_id_sports_leagues_id_fk": {
+          "name": "seasons_sports_league_id_sports_leagues_id_fk",
+          "tableFrom": "seasons",
+          "tableTo": "sports_leagues",
+          "columnsFrom": ["sports_league_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "seasons_league_year_uniq": {
+          "name": "seasons_league_year_uniq",
+          "nullsNotDistinct": false,
+          "columns": ["sports_league_id", "year"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sports_leagues": {
+      "name": "sports_leagues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sport": {
+          "name": "sport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sports_leagues_abbreviation_unique": {
+          "name": "sports_leagues_abbreviation_unique",
+          "nullsNotDistinct": false,
+          "columns": ["abbreviation"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sportsbooks": {
+      "name": "sportsbooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sportsbooks_name_unique": {
+          "name": "sportsbooks_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sports_league_id": {
+          "name": "sports_league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_dark_url": {
+          "name": "logo_dark_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teams_sports_league_id_idx": {
+          "name": "teams_sports_league_id_idx",
+          "columns": [
+            {
+              "expression": "sports_league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_sports_league_id_sports_leagues_id_fk": {
+          "name": "teams_sports_league_id_sports_leagues_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "sports_leagues",
+          "columnsFrom": ["sports_league_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.league_role": {
+      "name": "league_role",
+      "schema": "public",
+      "values": ["commissioner", "member"]
+    },
+    "public.pick_type": {
+      "name": "pick_type",
+      "schema": "public",
+      "values": ["straight_up", "against_the_spread"]
+    },
+    "public.pick_result": {
+      "name": "pick_result",
+      "schema": "public",
+      "values": ["win", "loss", "push"]
+    },
+    "public.profile_role": {
+      "name": "profile_role",
+      "schema": "public",
+      "values": ["user", "admin"]
+    },
+    "public.event_status": {
+      "name": "event_status",
+      "schema": "public",
+      "values": ["not_started", "in_progress", "final"]
+    },
+    "public.season_type": {
+      "name": "season_type",
+      "schema": "public",
+      "values": ["regular", "postseason"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1776621234567,
       "tag": "0008_custom_league_schedules",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1776572867497,
+      "tag": "0009_picks_table",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema/picks.ts
+++ b/lib/db/schema/picks.ts
@@ -1,0 +1,63 @@
+import {
+  doublePrecision,
+  index,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+  uuid,
+} from "drizzle-orm/pg-core";
+
+import { user } from "./auth";
+import { leagues } from "./leagues";
+import { events, phases, teams } from "./sports";
+
+export const pickResultEnum = pgEnum("pick_result", ["win", "loss", "push"]);
+
+export type PickResult = (typeof pickResultEnum.enumValues)[number];
+
+export const picks = pgTable(
+  "picks",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    leagueId: uuid("league_id")
+      .notNull()
+      .references(() => leagues.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    phaseId: uuid("phase_id")
+      .notNull()
+      .references(() => phases.id, { onDelete: "cascade" }),
+    eventId: uuid("event_id")
+      .notNull()
+      .references(() => events.id, { onDelete: "cascade" }),
+    teamId: uuid("team_id")
+      .notNull()
+      .references(() => teams.id, { onDelete: "restrict" }),
+    // Frozen spread for against-the-spread leagues. Null for straight-up
+    // leagues. The spread used at submission time is the one that counts
+    // for scoring, even if the line later moves (BUSINESS_SPEC §9.3).
+    spreadAtLock: doublePrecision("spread_at_lock"),
+    pickResult: pickResultEnum("pick_result"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => [
+    unique("picks_league_user_event_uniq").on(
+      table.leagueId,
+      table.userId,
+      table.eventId,
+    ),
+    index("picks_league_user_idx").on(table.leagueId, table.userId),
+    index("picks_phase_id_idx").on(table.phaseId),
+    index("picks_event_id_idx").on(table.eventId),
+  ],
+);
+
+export type Pick = typeof picks.$inferSelect;
+export type NewPick = typeof picks.$inferInsert;

--- a/lib/db/schema/relations.ts
+++ b/lib/db/schema/relations.ts
@@ -15,6 +15,7 @@ import {
   leagues,
   linkInvites,
 } from "./leagues";
+import { picks } from "./picks";
 import {
   dataSources,
   events,
@@ -48,6 +49,7 @@ export const phasesRelations = relations(phases, ({ one, many }) => ({
     references: [seasons.id],
   }),
   events: many(events),
+  picks: many(picks),
 }));
 
 export const teamsRelations = relations(teams, ({ one }) => ({
@@ -73,6 +75,7 @@ export const eventsRelations = relations(events, ({ one, many }) => ({
     relationName: "awayTeam",
   }),
   odds: many(odds),
+  picks: many(picks),
 }));
 
 export const oddsRelations = relations(odds, ({ one }) => ({
@@ -158,6 +161,7 @@ export const leaguesRelations = relations(leagues, ({ one, many }) => ({
   }),
   members: many(leagueMembers),
   standings: many(leagueStandings),
+  picks: many(picks),
 }));
 
 export const leagueMembersRelations = relations(leagueMembers, ({ one }) => ({
@@ -204,5 +208,28 @@ export const linkInvitesRelations = relations(linkInvites, ({ one }) => ({
   league: one(leagues, {
     fields: [linkInvites.leagueId],
     references: [leagues.id],
+  }),
+}));
+
+export const picksRelations = relations(picks, ({ one }) => ({
+  league: one(leagues, {
+    fields: [picks.leagueId],
+    references: [leagues.id],
+  }),
+  user: one(user, {
+    fields: [picks.userId],
+    references: [user.id],
+  }),
+  phase: one(phases, {
+    fields: [picks.phaseId],
+    references: [phases.id],
+  }),
+  event: one(events, {
+    fields: [picks.eventId],
+    references: [events.id],
+  }),
+  team: one(teams, {
+    fields: [picks.teamId],
+    references: [teams.id],
   }),
 }));

--- a/lib/nfl/leagues.test.ts
+++ b/lib/nfl/leagues.test.ts
@@ -14,6 +14,7 @@ import {
   selectCurrentSeason,
   selectLeagueCurrentPhase,
   selectLeagueStartPhase,
+  selectStandingsSeason,
   type LeagueRange,
 } from "./leagues";
 
@@ -552,6 +553,62 @@ describe("selectLeagueCurrentPhase", () => {
   it("returns null when the range has no synced phases", () => {
     expect(
       selectLeagueCurrentPhase([week1], postseasonRange, new Date()),
+    ).toBeNull();
+  });
+});
+
+describe("selectStandingsSeason", () => {
+  const year2024 = season({ year: 2024 });
+  const year2025 = season({ year: 2025 });
+  const year2026 = season({ year: 2026 });
+
+  it("honors ?season when it's in the historical list", () => {
+    expect(
+      selectStandingsSeason({
+        seasonsWithStandings: [year2024, year2025],
+        currentSeason: year2026,
+        requestedSeasonId: year2024.id,
+      }),
+    ).toEqual(year2024);
+  });
+
+  it("ignores a stale ?season and falls back to the current season when it has standings", () => {
+    expect(
+      selectStandingsSeason({
+        seasonsWithStandings: [year2025, year2026],
+        currentSeason: year2026,
+        requestedSeasonId: "bogus-id",
+      }),
+    ).toEqual(year2026);
+  });
+
+  it("falls back to the most recent historical season when the current one has no standings", () => {
+    expect(
+      selectStandingsSeason({
+        seasonsWithStandings: [year2024, year2025],
+        currentSeason: year2026,
+        requestedSeasonId: null,
+      }),
+    ).toEqual(year2025);
+  });
+
+  it("returns the current season for a brand-new league (no standings yet)", () => {
+    expect(
+      selectStandingsSeason({
+        seasonsWithStandings: [],
+        currentSeason: year2026,
+        requestedSeasonId: null,
+      }),
+    ).toEqual(year2026);
+  });
+
+  it("returns null when no seasons are available at all", () => {
+    expect(
+      selectStandingsSeason({
+        seasonsWithStandings: [],
+        currentSeason: null,
+        requestedSeasonId: null,
+      }),
     ).toBeNull();
   });
 });

--- a/lib/nfl/leagues.test.ts
+++ b/lib/nfl/leagues.test.ts
@@ -1,15 +1,18 @@
 import { describe, expect, it } from "vitest";
 
-import type { Phase, Season } from "@/lib/db/schema/sports";
+import type { Event, Phase, Season } from "@/lib/db/schema/sports";
 
 import {
   formatLeagueRange,
   getLeagueSeasonState,
   hasLeagueStartLockPassed,
   isPhaseInLeagueRange,
+  isPhaseLocked,
+  isPickLocked,
   isValidLeagueRange,
   phaseLabel,
   selectCurrentSeason,
+  selectLeagueCurrentPhase,
   selectLeagueStartPhase,
   type LeagueRange,
 } from "./leagues";
@@ -464,5 +467,138 @@ describe("hasLeagueStartLockPassed", () => {
         new Date("2099-01-01T00:00:00Z"),
       ),
     ).toBe(false);
+  });
+});
+
+describe("selectLeagueCurrentPhase", () => {
+  const week1 = phase({
+    seasonType: "regular",
+    startDate: new Date("2025-09-07T00:00:00Z"),
+    endDate: new Date("2025-09-14T00:00:00Z"),
+    weekNumber: 1,
+  });
+  const week2 = phase({
+    seasonType: "regular",
+    startDate: new Date("2025-09-14T00:00:00Z"),
+    endDate: new Date("2025-09-21T00:00:00Z"),
+    weekNumber: 2,
+  });
+  const week18 = phase({
+    seasonType: "regular",
+    startDate: new Date("2026-01-04T00:00:00Z"),
+    endDate: new Date("2026-01-11T00:00:00Z"),
+    weekNumber: 18,
+  });
+  const wildCard = phase({
+    seasonType: "postseason",
+    startDate: new Date("2026-01-11T00:00:00Z"),
+    endDate: new Date("2026-01-18T00:00:00Z"),
+    weekNumber: 1,
+  });
+
+  it("returns the active phase when now falls inside it", () => {
+    const now = new Date("2025-09-10T12:00:00Z");
+    expect(
+      selectLeagueCurrentPhase(
+        [week1, week2, week18, wildCard],
+        regularSeasonRange,
+        now,
+      ),
+    ).toEqual(week1);
+  });
+
+  it("returns the nearest upcoming phase between weeks", () => {
+    const now = new Date("2025-09-21T00:00:00Z");
+    expect(
+      selectLeagueCurrentPhase([week1, week2, week18], regularSeasonRange, now),
+    ).toEqual(week18);
+  });
+
+  it("returns the latest phase after the season ends", () => {
+    const now = new Date("2026-06-01T00:00:00Z");
+    expect(
+      selectLeagueCurrentPhase([week1, week2, week18], regularSeasonRange, now),
+    ).toEqual(week18);
+  });
+
+  it("returns the first phase before the season starts", () => {
+    const now = new Date("2025-08-01T00:00:00Z");
+    expect(
+      selectLeagueCurrentPhase([week1, week2, week18], regularSeasonRange, now),
+    ).toEqual(week1);
+  });
+
+  it("ignores phases outside the league range", () => {
+    // During the wild card week; regular-season-only league defaults back to
+    // its last week rather than jumping to the postseason phase.
+    const now = new Date("2026-01-15T00:00:00Z");
+    expect(
+      selectLeagueCurrentPhase(
+        [week1, week2, week18, wildCard],
+        regularSeasonRange,
+        now,
+      ),
+    ).toEqual(week18);
+    // Postseason-only league resolves to wild card during the same moment.
+    expect(
+      selectLeagueCurrentPhase(
+        [week1, week2, week18, wildCard],
+        postseasonRange,
+        now,
+      ),
+    ).toEqual(wildCard);
+  });
+
+  it("returns null when the range has no synced phases", () => {
+    expect(
+      selectLeagueCurrentPhase([week1], postseasonRange, new Date()),
+    ).toBeNull();
+  });
+});
+
+describe("isPhaseLocked", () => {
+  const phaseLock = {
+    pickLockTime: new Date("2025-09-07T17:00:00Z"),
+  } as Pick<Phase, "pickLockTime">;
+
+  it("returns false before pick lock time", () => {
+    expect(isPhaseLocked(phaseLock, new Date("2025-09-07T16:59:59Z"))).toBe(
+      false,
+    );
+  });
+
+  it("returns true at the pick lock time", () => {
+    expect(isPhaseLocked(phaseLock, new Date("2025-09-07T17:00:00Z"))).toBe(
+      true,
+    );
+  });
+});
+
+describe("isPickLocked", () => {
+  const sundayGame = {
+    startTime: new Date("2025-09-07T17:00:00Z"),
+  } as Pick<Event, "startTime">;
+  const thursdayNightGame = {
+    startTime: new Date("2025-09-04T00:20:00Z"),
+  } as Pick<Event, "startTime">;
+  const phaseLock = {
+    pickLockTime: new Date("2025-09-07T17:00:00Z"),
+  } as Pick<Phase, "pickLockTime">;
+
+  it("returns false before both the phase lock and the game start", () => {
+    const now = new Date("2025-09-03T00:00:00Z");
+    expect(isPickLocked(phaseLock, sundayGame, now)).toBe(false);
+  });
+
+  it("returns true at the phase lock time", () => {
+    const now = new Date("2025-09-07T17:00:00Z");
+    expect(isPickLocked(phaseLock, sundayGame, now)).toBe(true);
+  });
+
+  it("returns true when the individual game has kicked off before the phase lock", () => {
+    const now = new Date("2025-09-04T00:30:00Z");
+    expect(isPickLocked(phaseLock, thursdayNightGame, now)).toBe(true);
+    // But a Sunday game is still unlocked at the same moment.
+    expect(isPickLocked(phaseLock, sundayGame, now)).toBe(false);
   });
 });

--- a/lib/nfl/leagues.test.ts
+++ b/lib/nfl/leagues.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import type { Event, Phase, Season } from "@/lib/db/schema/sports";
+import type { Phase, Season } from "@/lib/db/schema/sports";
 
 import {
   formatLeagueRange,
@@ -8,6 +8,7 @@ import {
   hasLeagueStartLockPassed,
   isPhaseInLeagueRange,
   isPhaseLocked,
+  hasEventStarted,
   isPickLocked,
   isValidLeagueRange,
   phaseLabel,
@@ -633,11 +634,13 @@ describe("isPhaseLocked", () => {
 
 describe("isPickLocked", () => {
   const sundayGame = {
+    status: "not_started" as const,
     startTime: new Date("2025-09-07T17:00:00Z"),
-  } as Pick<Event, "startTime">;
+  };
   const thursdayNightGame = {
+    status: "not_started" as const,
     startTime: new Date("2025-09-04T00:20:00Z"),
-  } as Pick<Event, "startTime">;
+  };
   const phaseLock = {
     pickLockTime: new Date("2025-09-07T17:00:00Z"),
   } as Pick<Phase, "pickLockTime">;
@@ -657,5 +660,52 @@ describe("isPickLocked", () => {
     expect(isPickLocked(phaseLock, thursdayNightGame, now)).toBe(true);
     // But a Sunday game is still unlocked at the same moment.
     expect(isPickLocked(phaseLock, sundayGame, now)).toBe(false);
+  });
+
+  it("returns true when status is in_progress or final even if startTime is still in the future", () => {
+    // Admin override can flip status without touching startTime. Status
+    // must win over the time-based fallback.
+    const now = new Date("2025-09-03T00:00:00Z");
+    const inProgress = { ...sundayGame, status: "in_progress" as const };
+    const final = { ...sundayGame, status: "final" as const };
+    expect(isPickLocked(phaseLock, inProgress, now)).toBe(true);
+    expect(isPickLocked(phaseLock, final, now)).toBe(true);
+  });
+});
+
+describe("hasEventStarted", () => {
+  const scheduled = {
+    status: "not_started" as const,
+    startTime: new Date("2025-09-07T17:00:00Z"),
+  };
+
+  it("returns false for a not_started game before its startTime", () => {
+    expect(hasEventStarted(scheduled, new Date("2025-09-03T00:00:00Z"))).toBe(
+      false,
+    );
+  });
+
+  it("returns true for a not_started game at/after its startTime", () => {
+    expect(hasEventStarted(scheduled, new Date("2025-09-07T17:00:00Z"))).toBe(
+      true,
+    );
+  });
+
+  it("returns true for in_progress status even before startTime", () => {
+    expect(
+      hasEventStarted(
+        { ...scheduled, status: "in_progress" },
+        new Date("2025-09-03T00:00:00Z"),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true for final status even before startTime", () => {
+    expect(
+      hasEventStarted(
+        { ...scheduled, status: "final" },
+        new Date("2025-09-03T00:00:00Z"),
+      ),
+    ).toBe(true);
   });
 });

--- a/lib/nfl/leagues.ts
+++ b/lib/nfl/leagues.ts
@@ -141,6 +141,57 @@ export function getLeagueSeasonState(
   return "in_progress";
 }
 
+// --- Phase-view resolution (shared by My Picks / League Picks pages) ---
+
+export type PhaseViewResolution =
+  | {
+      kind: "ok";
+      phasesInRange: Phase[];
+      selectedPhase: Phase;
+      prevPhase: Phase | null;
+      nextPhase: Phase | null;
+    }
+  | { kind: "no-phases-in-range" };
+
+/**
+ * Shared phase-resolution for any page rendering "pick view for one phase
+ * in this league" — filters the season's phases to the league's range,
+ * honors `?phase=<id>` when it points at an in-range phase, falls back to
+ * `selectLeagueCurrentPhase`, and computes prev/next neighbors. Returns a
+ * discriminated result so the caller can render a distinct empty state
+ * when the league range has no synced phases.
+ */
+export function resolvePhaseView(params: {
+  league: LeagueRange;
+  allPhases: Phase[];
+  requestedPhaseId: string | null;
+  now: Date;
+}): PhaseViewResolution {
+  const phasesInRange = params.allPhases
+    .filter((p) => isPhaseInLeagueRange(p, params.league))
+    .sort(comparePhasesByOrdinal);
+
+  const requestedPhase = params.requestedPhaseId
+    ? (phasesInRange.find((p) => p.id === params.requestedPhaseId) ?? null)
+    : null;
+  const selectedPhase =
+    requestedPhase ??
+    selectLeagueCurrentPhase(params.allPhases, params.league, params.now);
+
+  if (!selectedPhase) return { kind: "no-phases-in-range" };
+
+  const currentIndex = phasesInRange.findIndex(
+    (p) => p.id === selectedPhase.id,
+  );
+  const prevPhase = currentIndex > 0 ? phasesInRange[currentIndex - 1] : null;
+  const nextPhase =
+    currentIndex >= 0 && currentIndex < phasesInRange.length - 1
+      ? phasesInRange[currentIndex + 1]
+      : null;
+
+  return { kind: "ok", phasesInRange, selectedPhase, prevPhase, nextPhase };
+}
+
 // --- Phase resolution for the picks view ---
 
 /**

--- a/lib/nfl/leagues.ts
+++ b/lib/nfl/leagues.ts
@@ -1,5 +1,5 @@
 import type { League } from "@/lib/db/schema/leagues";
-import type { Phase, Season, SeasonType } from "@/lib/db/schema/sports";
+import type { Event, Phase, Season, SeasonType } from "@/lib/db/schema/sports";
 
 /**
  * A league's schedule range is an ordered pair of (seasonType, weekNumber)
@@ -139,4 +139,60 @@ export function getLeagueSeasonState(
   if (now.getTime() < earliestStart) return "upcoming";
   if (now.getTime() >= latestEnd) return "complete";
   return "in_progress";
+}
+
+// --- Phase resolution for the picks view ---
+
+/**
+ * BUSINESS_SPEC §6.3: picks views default to the currently-active phase;
+ * when nothing is active we show the nearest upcoming phase, and after the
+ * league's season is over we show its final phase.
+ *
+ * Only phases inside the league's range are considered — a postseason-only
+ * league never defaults to a regular-season week.
+ */
+export function selectLeagueCurrentPhase(
+  phases: Phase[],
+  range: LeagueRange,
+  now: Date,
+): Phase | null {
+  const relevant = phases.filter((p) => isPhaseInLeagueRange(p, range));
+  if (relevant.length === 0) return null;
+
+  const active = relevant.find((p) => now >= p.startDate && now < p.endDate);
+  if (active) return active;
+
+  const upcoming = relevant
+    .filter((p) => p.startDate.getTime() > now.getTime())
+    .sort((a, b) => a.startDate.getTime() - b.startDate.getTime())[0];
+  if (upcoming) return upcoming;
+
+  return [...relevant].sort(
+    (a, b) => b.startDate.getTime() - a.startDate.getTime(),
+  )[0];
+}
+
+// --- Pick lock gates ---
+
+export function isPhaseLocked(
+  phase: Pick<Phase, "pickLockTime">,
+  now: Date,
+): boolean {
+  return now.getTime() >= phase.pickLockTime.getTime();
+}
+
+/**
+ * BUSINESS_SPEC §7.1 / §7.2: picks are locked when either the phase's pick
+ * lock time has passed OR the specific game has already kicked off. The
+ * per-event kickoff gate fires ahead of the phase-wide lock for early
+ * games (e.g. Thursday Night Football in an NFL week).
+ */
+export function isPickLocked(
+  phase: Pick<Phase, "pickLockTime">,
+  event: Pick<Event, "startTime">,
+  now: Date,
+): boolean {
+  return (
+    isPhaseLocked(phase, now) || now.getTime() >= event.startTime.getTime()
+  );
 }

--- a/lib/nfl/leagues.ts
+++ b/lib/nfl/leagues.ts
@@ -172,6 +172,44 @@ export function selectLeagueCurrentPhase(
   )[0];
 }
 
+// --- Standings season selection ---
+
+/**
+ * BUSINESS_SPEC §3.5 / §12.4: the Standings tab shows the current season
+ * by default and supports navigating to prior seasons. Resolution order:
+ * explicit `?season` param (if present in the historical list) → the
+ * current season (if the league has standings for it) → the most recent
+ * historical season with standings → the current season as a last resort
+ * so new leagues render an empty-standings state with the right year.
+ */
+export function selectStandingsSeason({
+  seasonsWithStandings,
+  currentSeason,
+  requestedSeasonId,
+}: {
+  seasonsWithStandings: Season[];
+  currentSeason: Season | null;
+  requestedSeasonId: string | null;
+}): Season | null {
+  if (requestedSeasonId) {
+    const requested = seasonsWithStandings.find(
+      (s) => s.id === requestedSeasonId,
+    );
+    if (requested) return requested;
+  }
+  if (currentSeason) {
+    const currentWithStandings = seasonsWithStandings.find(
+      (s) => s.id === currentSeason.id,
+    );
+    if (currentWithStandings) return currentWithStandings;
+  }
+  const mostRecentHistorical = [...seasonsWithStandings].sort(
+    (a, b) => b.year - a.year,
+  )[0];
+  if (mostRecentHistorical) return mostRecentHistorical;
+  return currentSeason;
+}
+
 // --- Pick lock gates ---
 
 export function isPhaseLocked(

--- a/lib/nfl/leagues.ts
+++ b/lib/nfl/leagues.ts
@@ -271,6 +271,22 @@ export function isPhaseLocked(
 }
 
 /**
+ * A game is "started" once either its status has moved off `not_started`
+ * OR wall-clock time has reached its scheduled kickoff. Status is the
+ * authoritative signal — an admin can flip a game to `in_progress` /
+ * `final` via override without touching `startTime`, and we still need
+ * to lock picks. Time is the fallback that covers the common case of
+ * ESPN sync being slightly behind kickoff.
+ */
+export function hasEventStarted(
+  event: Pick<Event, "status" | "startTime">,
+  now: Date,
+): boolean {
+  if (event.status !== "not_started") return true;
+  return now.getTime() >= event.startTime.getTime();
+}
+
+/**
  * BUSINESS_SPEC §7.1 / §7.2: picks are locked when either the phase's pick
  * lock time has passed OR the specific game has already kicked off. The
  * per-event kickoff gate fires ahead of the phase-wide lock for early
@@ -278,10 +294,8 @@ export function isPhaseLocked(
  */
 export function isPickLocked(
   phase: Pick<Phase, "pickLockTime">,
-  event: Pick<Event, "startTime">,
+  event: Pick<Event, "status" | "startTime">,
   now: Date,
 ): boolean {
-  return (
-    isPhaseLocked(phase, now) || now.getTime() >= event.startTime.getTime()
-  );
+  return isPhaseLocked(phase, now) || hasEventStarted(event, now);
 }

--- a/lib/nfl/scheduling.ts
+++ b/lib/nfl/scheduling.ts
@@ -1,8 +1,17 @@
-import { fromZonedTime, toZonedTime } from "date-fns-tz";
+import { formatInTimeZone, fromZonedTime, toZonedTime } from "date-fns-tz";
 
 import type { EventStatus, SeasonType } from "@/lib/db/schema/sports";
 
-const EASTERN_TZ = "America/New_York";
+export const EASTERN_TZ = "America/New_York";
+
+/**
+ * Shared Eastern-time formatter for pick-lock banners and event kickoff
+ * display. NFL game times + §6.2 pick locks are defined in ET, so the
+ * UI consistently renders in ET.
+ */
+export function formatEasternDateTime(date: Date): string {
+  return formatInTimeZone(date, EASTERN_TZ, "EEE MMM d, h:mm a 'ET'");
+}
 const LOCK_HOUR = 13; // 1:00 PM
 const BOUNDARY_HOUR = 2; // 2:00 AM
 

--- a/lib/nfl/scoring.test.ts
+++ b/lib/nfl/scoring.test.ts
@@ -5,6 +5,7 @@ import type { EventStatus } from "@/lib/db/schema/sports";
 import {
   calculatePickResult,
   calculateStandingsPoints,
+  calculateWeeklyStandings,
   denseRank,
 } from "./scoring";
 
@@ -301,5 +302,90 @@ describe("denseRank (§8.4)", () => {
 
   it("returns an empty list when given no entries", () => {
     expect(denseRank([], (e: { p: number }) => e.p)).toEqual([]);
+  });
+});
+
+describe("calculateWeeklyStandings", () => {
+  it("aggregates per-user wins/losses/pushes and ranks by points", () => {
+    const standings = calculateWeeklyStandings(
+      [
+        // user-a: 2 wins, 1 push → 2.5 pts
+        { userId: "user-a", pickResult: "win" },
+        { userId: "user-a", pickResult: "win" },
+        { userId: "user-a", pickResult: "push" },
+        // user-b: 1 win, 2 losses → 1 pt
+        { userId: "user-b", pickResult: "win" },
+        { userId: "user-b", pickResult: "loss" },
+        { userId: "user-b", pickResult: "loss" },
+        // user-c: 2 wins → 2 pts
+        { userId: "user-c", pickResult: "win" },
+        { userId: "user-c", pickResult: "win" },
+      ],
+      ["user-a", "user-b", "user-c"],
+    );
+
+    expect(standings).toEqual([
+      {
+        userId: "user-a",
+        wins: 2,
+        losses: 0,
+        pushes: 1,
+        points: 2.5,
+        rank: 1,
+      },
+      { userId: "user-c", wins: 2, losses: 0, pushes: 0, points: 2, rank: 2 },
+      { userId: "user-b", wins: 1, losses: 2, pushes: 0, points: 1, rank: 3 },
+    ]);
+  });
+
+  it("includes members with no picks at 0-0-0 so ranks account for them", () => {
+    const standings = calculateWeeklyStandings(
+      [{ userId: "user-a", pickResult: "win" }],
+      ["user-a", "user-b"],
+    );
+    expect(standings).toEqual([
+      { userId: "user-a", wins: 1, losses: 0, pushes: 0, points: 1, rank: 1 },
+      { userId: "user-b", wins: 0, losses: 0, pushes: 0, points: 0, rank: 2 },
+    ]);
+  });
+
+  it("ignores picks from users not in the member list (§4.3 former members)", () => {
+    const standings = calculateWeeklyStandings(
+      [
+        { userId: "user-a", pickResult: "win" },
+        { userId: "removed-member", pickResult: "win" },
+      ],
+      ["user-a"],
+    );
+    expect(standings).toEqual([
+      { userId: "user-a", wins: 1, losses: 0, pushes: 0, points: 1, rank: 1 },
+    ]);
+  });
+
+  it("treats unscored (null) picks as 0 points without counting W/L/P", () => {
+    const standings = calculateWeeklyStandings(
+      [
+        { userId: "user-a", pickResult: null },
+        { userId: "user-a", pickResult: "win" },
+      ],
+      ["user-a"],
+    );
+    expect(standings[0]).toEqual({
+      userId: "user-a",
+      wins: 1,
+      losses: 0,
+      pushes: 0,
+      points: 1,
+      rank: 1,
+    });
+  });
+
+  it("all-tied members share rank 1", () => {
+    const standings = calculateWeeklyStandings(
+      [],
+      ["user-a", "user-b", "user-c"],
+    );
+    expect(standings.every((s) => s.rank === 1)).toBe(true);
+    expect(standings.every((s) => s.points === 0)).toBe(true);
   });
 });

--- a/lib/nfl/scoring.test.ts
+++ b/lib/nfl/scoring.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from "vitest";
+
+import type { EventStatus } from "@/lib/db/schema/sports";
+
+import {
+  calculatePickResult,
+  calculateStandingsPoints,
+  denseRank,
+} from "./scoring";
+
+const HOME = "home-team-id";
+const AWAY = "away-team-id";
+
+function event(
+  overrides: Partial<{
+    status: EventStatus;
+    homeScore: number | null;
+    awayScore: number | null;
+  }> = {},
+) {
+  return {
+    status: overrides.status ?? ("final" as EventStatus),
+    homeTeamId: HOME,
+    awayTeamId: AWAY,
+    homeScore: overrides.homeScore === undefined ? 0 : overrides.homeScore,
+    awayScore: overrides.awayScore === undefined ? 0 : overrides.awayScore,
+  };
+}
+
+describe("calculatePickResult — straight up", () => {
+  it("returns win when the picked team's score is higher", () => {
+    expect(
+      calculatePickResult(
+        { teamId: HOME, spreadAtLock: null },
+        event({ homeScore: 24, awayScore: 17 }),
+        "straight_up",
+      ),
+    ).toBe("win");
+    expect(
+      calculatePickResult(
+        { teamId: AWAY, spreadAtLock: null },
+        event({ homeScore: 17, awayScore: 24 }),
+        "straight_up",
+      ),
+    ).toBe("win");
+  });
+
+  it("returns loss when the picked team's score is lower", () => {
+    expect(
+      calculatePickResult(
+        { teamId: HOME, spreadAtLock: null },
+        event({ homeScore: 10, awayScore: 20 }),
+        "straight_up",
+      ),
+    ).toBe("loss");
+  });
+
+  it("returns push on a tie", () => {
+    expect(
+      calculatePickResult(
+        { teamId: HOME, spreadAtLock: null },
+        event({ homeScore: 17, awayScore: 17 }),
+        "straight_up",
+      ),
+    ).toBe("push");
+  });
+});
+
+describe("calculatePickResult — against the spread", () => {
+  it("applies the frozen spread to the picked team's score (favorite wins ATS)", () => {
+    // Picked home at -3.5. Home wins 24-17. Adjusted = 24 - 3.5 = 20.5 > 17 → win.
+    expect(
+      calculatePickResult(
+        { teamId: HOME, spreadAtLock: -3.5 },
+        event({ homeScore: 24, awayScore: 17 }),
+        "against_the_spread",
+      ),
+    ).toBe("win");
+  });
+
+  it("favorite loses ATS when the margin is smaller than the spread", () => {
+    // Picked home at -7. Home wins 21-17. Adjusted = 21 - 7 = 14 < 17 → loss.
+    expect(
+      calculatePickResult(
+        { teamId: HOME, spreadAtLock: -7 },
+        event({ homeScore: 21, awayScore: 17 }),
+        "against_the_spread",
+      ),
+    ).toBe("loss");
+  });
+
+  it("underdog wins outright and also covers ATS", () => {
+    // Picked away at +3.5. Away wins 17-14. Adjusted = 17 + 3.5 = 20.5 > 14 → win.
+    expect(
+      calculatePickResult(
+        { teamId: AWAY, spreadAtLock: 3.5 },
+        event({ homeScore: 14, awayScore: 17 }),
+        "against_the_spread",
+      ),
+    ).toBe("win");
+  });
+
+  it("underdog loses outright but covers ATS", () => {
+    // Picked away at +7. Home wins 24-20. Adjusted = 20 + 7 = 27 > 24 → win.
+    expect(
+      calculatePickResult(
+        { teamId: AWAY, spreadAtLock: 7 },
+        event({ homeScore: 24, awayScore: 20 }),
+        "against_the_spread",
+      ),
+    ).toBe("win");
+  });
+
+  it("returns push when adjusted score exactly equals the opponent", () => {
+    // Picked home at -3. Home wins 24-21. Adjusted = 24 - 3 = 21 = 21 → push.
+    expect(
+      calculatePickResult(
+        { teamId: HOME, spreadAtLock: -3 },
+        event({ homeScore: 24, awayScore: 21 }),
+        "against_the_spread",
+      ),
+    ).toBe("push");
+  });
+
+  it("pick'em (spread 0) scores like straight up", () => {
+    expect(
+      calculatePickResult(
+        { teamId: HOME, spreadAtLock: 0 },
+        event({ homeScore: 21, awayScore: 17 }),
+        "against_the_spread",
+      ),
+    ).toBe("win");
+    expect(
+      calculatePickResult(
+        { teamId: HOME, spreadAtLock: 0 },
+        event({ homeScore: 17, awayScore: 17 }),
+        "against_the_spread",
+      ),
+    ).toBe("push");
+  });
+
+  it("returns null when an ATS pick has no frozen spread", () => {
+    expect(
+      calculatePickResult(
+        { teamId: HOME, spreadAtLock: null },
+        event({ homeScore: 24, awayScore: 17 }),
+        "against_the_spread",
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("calculatePickResult — unscoreable states", () => {
+  it("returns null when the event is not final", () => {
+    expect(
+      calculatePickResult(
+        { teamId: HOME, spreadAtLock: null },
+        event({ status: "in_progress", homeScore: 14, awayScore: 7 }),
+        "straight_up",
+      ),
+    ).toBeNull();
+    expect(
+      calculatePickResult(
+        { teamId: HOME, spreadAtLock: null },
+        event({ status: "not_started", homeScore: null, awayScore: null }),
+        "straight_up",
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when scores are missing on a final event", () => {
+    expect(
+      calculatePickResult(
+        { teamId: HOME, spreadAtLock: null },
+        event({ status: "final", homeScore: null, awayScore: 17 }),
+        "straight_up",
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when the picked team isn't home or away of this event", () => {
+    expect(
+      calculatePickResult(
+        { teamId: "mystery-team", spreadAtLock: null },
+        event({ homeScore: 24, awayScore: 17 }),
+        "straight_up",
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("calculateStandingsPoints", () => {
+  it("sums wins, losses, pushes and points per §8.2", () => {
+    expect(calculateStandingsPoints(["win", "win", "loss", "push"])).toEqual({
+      wins: 2,
+      losses: 1,
+      pushes: 1,
+      points: 2.5,
+    });
+  });
+
+  it("ignores unscored picks (null)", () => {
+    expect(
+      calculateStandingsPoints(["win", null, null, "push", "loss"]),
+    ).toEqual({
+      wins: 1,
+      losses: 1,
+      pushes: 1,
+      points: 1.5,
+    });
+  });
+
+  it("zeros out an empty list", () => {
+    expect(calculateStandingsPoints([])).toEqual({
+      wins: 0,
+      losses: 0,
+      pushes: 0,
+      points: 0,
+    });
+  });
+});
+
+describe("denseRank (§8.4)", () => {
+  it("assigns rank 1 to the single highest scorer", () => {
+    const ranked = denseRank(
+      [
+        { id: "a", p: 5 },
+        { id: "b", p: 3 },
+        { id: "c", p: 1 },
+      ],
+      (e) => e.p,
+    );
+    expect(ranked.map((r) => [r.entry.id, r.rank])).toEqual([
+      ["a", 1],
+      ["b", 2],
+      ["c", 3],
+    ]);
+  });
+
+  it("ties share a rank and the next distinct rank jumps by the tied count", () => {
+    const ranked = denseRank(
+      [
+        { id: "a", p: 5 },
+        { id: "b", p: 5 },
+        { id: "c", p: 3 },
+      ],
+      (e) => e.p,
+    );
+    // a & b tied at 1 (2 tied) → next distinct rank = 1 + 2 = 3.
+    expect(ranked.map((r) => [r.entry.id, r.rank])).toEqual([
+      ["a", 1],
+      ["b", 1],
+      ["c", 3],
+    ]);
+  });
+
+  it("handles multiple distinct tie groups", () => {
+    // [5,5,3,3,1] → ranks [1,1,3,3,5]
+    const ranked = denseRank(
+      [
+        { id: "a", p: 5 },
+        { id: "b", p: 5 },
+        { id: "c", p: 3 },
+        { id: "d", p: 3 },
+        { id: "e", p: 1 },
+      ],
+      (e) => e.p,
+    );
+    expect(ranked.map((r) => [r.entry.id, r.rank])).toEqual([
+      ["a", 1],
+      ["b", 1],
+      ["c", 3],
+      ["d", 3],
+      ["e", 5],
+    ]);
+  });
+
+  it("handles all-tied at rank 1", () => {
+    const ranked = denseRank(
+      [
+        { id: "a", p: 0 },
+        { id: "b", p: 0 },
+        { id: "c", p: 0 },
+      ],
+      (e) => e.p,
+    );
+    expect(ranked.every((r) => r.rank === 1)).toBe(true);
+  });
+
+  it("preserves points-desc ordering in the output", () => {
+    const ranked = denseRank(
+      [
+        { id: "a", p: 1 },
+        { id: "b", p: 3 },
+        { id: "c", p: 2 },
+      ],
+      (e) => e.p,
+    );
+    expect(ranked.map((r) => r.entry.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("returns an empty list when given no entries", () => {
+    expect(denseRank([], (e: { p: number }) => e.p)).toEqual([]);
+  });
+});

--- a/lib/nfl/scoring.ts
+++ b/lib/nfl/scoring.ts
@@ -1,0 +1,114 @@
+import type { PickType } from "@/lib/db/schema/leagues";
+import type { PickResult } from "@/lib/db/schema/picks";
+import type { Event } from "@/lib/db/schema/sports";
+
+export const POINTS_PER_WIN = 1;
+export const POINTS_PER_PUSH = 0.5;
+export const POINTS_PER_LOSS = 0;
+
+/**
+ * BUSINESS_SPEC §8.1.
+ *
+ * Returns null when the event isn't final or doesn't have both scores yet —
+ * callers treat null as "not yet scored." Once status is `final` and both
+ * scores exist, the result is deterministic from the event + the pick's
+ * frozen spread.
+ */
+export function calculatePickResult(
+  pick: { teamId: string; spreadAtLock: number | null },
+  event: Pick<
+    Event,
+    "status" | "homeTeamId" | "awayTeamId" | "homeScore" | "awayScore"
+  >,
+  pickType: PickType,
+): PickResult | null {
+  if (event.status !== "final") return null;
+  if (event.homeScore == null || event.awayScore == null) return null;
+
+  const pickedHome = pick.teamId === event.homeTeamId;
+  const pickedAway = pick.teamId === event.awayTeamId;
+  if (!pickedHome && !pickedAway) return null;
+
+  const pickedScore = pickedHome ? event.homeScore : event.awayScore;
+  const opponentScore = pickedHome ? event.awayScore : event.homeScore;
+
+  if (pickType === "straight_up") {
+    if (pickedScore > opponentScore) return "win";
+    if (pickedScore < opponentScore) return "loss";
+    return "push";
+  }
+
+  // ATS: the frozen spread is applied to the picked team's score.
+  // A null spread on an ATS league means we never captured a line — the
+  // pick can't be scored, so return null and let the caller re-score once
+  // odds populate (typically not reachable since the submission action
+  // rejects picks without a spread, but defensive).
+  if (pick.spreadAtLock == null) return null;
+  const adjustedPickedScore = pickedScore + pick.spreadAtLock;
+  if (adjustedPickedScore > opponentScore) return "win";
+  if (adjustedPickedScore < opponentScore) return "loss";
+  return "push";
+}
+
+export interface StandingTotals {
+  wins: number;
+  losses: number;
+  pushes: number;
+  points: number;
+}
+
+/**
+ * BUSINESS_SPEC §8.2 — points = wins + (pushes × 0.5). Unresolved picks
+ * (null pickResult) contribute nothing.
+ */
+export function calculateStandingsPoints(
+  results: readonly (PickResult | null)[],
+): StandingTotals {
+  let wins = 0;
+  let losses = 0;
+  let pushes = 0;
+  for (const result of results) {
+    if (result === "win") wins++;
+    else if (result === "loss") losses++;
+    else if (result === "push") pushes++;
+  }
+  const points = wins * POINTS_PER_WIN + pushes * POINTS_PER_PUSH;
+  return { wins, losses, pushes, points };
+}
+
+export interface RankedEntry<T> {
+  entry: T;
+  rank: number;
+}
+
+/**
+ * BUSINESS_SPEC §8.4 — dense ranking: tied entries share a rank; the
+ * next distinct rank after a tie is `previousRank + tiedCount`. Entries
+ * with equal `points` are considered tied.
+ *
+ * The input is not mutated; the result is sorted points-desc.
+ */
+export function denseRank<T>(
+  entries: T[],
+  getPoints: (entry: T) => number,
+): RankedEntry<T>[] {
+  const sorted = [...entries].sort((a, b) => getPoints(b) - getPoints(a));
+  const ranked: RankedEntry<T>[] = [];
+  let currentRank = 1;
+  let previousPoints: number | null = null;
+  let tiedCount = 0;
+  for (const entry of sorted) {
+    const points = getPoints(entry);
+    if (previousPoints === null || points < previousPoints) {
+      if (previousPoints !== null) {
+        currentRank += tiedCount;
+      }
+      tiedCount = 1;
+      previousPoints = points;
+    } else {
+      tiedCount++;
+    }
+    ranked.push({ entry, rank: currentRank });
+  }
+  return ranked;
+}

--- a/lib/nfl/scoring.ts
+++ b/lib/nfl/scoring.ts
@@ -87,6 +87,42 @@ export function calculateStandingsPoints(
   return { wins, losses, pushes, points };
 }
 
+export interface WeeklyStanding {
+  userId: string;
+  wins: number;
+  losses: number;
+  pushes: number;
+  points: number;
+  rank: number;
+}
+
+/**
+ * Per-phase standings for the given league members. Picks whose owner
+ * isn't in `userIds` are ignored (former-member picks are preserved in
+ * the DB per §4.3 but don't contribute to current standings). Members
+ * with no picks this phase appear with a zero row so ranks are consistent
+ * across everyone who should be compared.
+ */
+export function calculateWeeklyStandings(
+  picks: readonly { userId: string; pickResult: PickResult | null }[],
+  userIds: readonly string[],
+): WeeklyStanding[] {
+  const resultsByUser = new Map<string, (PickResult | null)[]>();
+  for (const id of userIds) resultsByUser.set(id, []);
+  for (const pick of picks) {
+    const bucket = resultsByUser.get(pick.userId);
+    if (bucket) bucket.push(pick.pickResult);
+  }
+  const rows = Array.from(resultsByUser.entries()).map(([userId, results]) => ({
+    userId,
+    ...calculateStandingsPoints(results),
+  }));
+  return denseRank(rows, (r) => r.points).map(({ entry, rank }) => ({
+    ...entry,
+    rank,
+  }));
+}
+
 export interface RankedEntry<T> {
   entry: T;
   rank: number;

--- a/lib/nfl/scoring.ts
+++ b/lib/nfl/scoring.ts
@@ -7,6 +7,17 @@ export const POINTS_PER_PUSH = 0.5;
 export const POINTS_PER_LOSS = 0;
 
 /**
+ * BUSINESS_SPEC §8.2 points are always `wins + 0.5 × pushes`, so values
+ * are either integer or ending in `.5`. Render whole numbers without a
+ * trailing decimal so the leaderboard doesn't read as "5.0" next to
+ * "4.5".
+ */
+export function formatPoints(points: number): string {
+  if (Number.isInteger(points)) return points.toString();
+  return points.toFixed(1);
+}
+
+/**
  * BUSINESS_SPEC §8.1.
  *
  * Returns null when the event isn't final or doesn't have both scores yet —

--- a/lib/simulator.test.ts
+++ b/lib/simulator.test.ts
@@ -47,6 +47,12 @@ vi.mock("@/lib/sync/nfl/setup", () => ({
   runInitialSetup: vi.fn(),
 }));
 
+vi.mock("@/lib/sync/nfl/standings", () => ({
+  runStandingsRecalc: vi
+    .fn()
+    .mockResolvedValue({ leaguesAffected: 0, picksRescored: 0 }),
+}));
+
 vi.mock("@/lib/espn/nfl/scores", () => ({
   fetchEventScore: vi.fn(),
 }));
@@ -65,6 +71,7 @@ const {
   getLockedEventIds,
 } = await import("@/data/events");
 const { runInitialSetup } = await import("@/lib/sync/nfl/setup");
+const { runStandingsRecalc } = await import("@/lib/sync/nfl/standings");
 const { fetchEventScore } = await import("@/lib/espn/nfl/scores");
 
 const mockGetSimulatorState = vi.mocked(getSimulatorState);
@@ -400,6 +407,9 @@ describe("advancePhase", () => {
       homeScore: 24,
       awayScore: 17,
     });
+    // §8.5: finalizing events inside the simulator must kick standings
+    // recalc, same as the live-scores sync path.
+    expect(runStandingsRecalc).toHaveBeenCalledTimes(1);
   });
 
   it("skips locked events when advancing", async () => {

--- a/lib/simulator.ts
+++ b/lib/simulator.ts
@@ -19,6 +19,7 @@ import { fetchEventScore } from "@/lib/espn/nfl/scores";
 import { BadRequestError, NotFoundError } from "@/lib/errors";
 import { findActivePhase } from "@/lib/nfl/scheduling";
 import { runInitialSetup } from "@/lib/sync/nfl/setup";
+import { runStandingsRecalc } from "@/lib/sync/nfl/standings";
 
 // Years before `now.getFullYear() - SIMULATOR_MAX_YEAR_OFFSET` are rejected.
 // Five-year window keeps the selectable range aligned with reliable ESPN history.
@@ -161,6 +162,16 @@ export async function advancePhase(): Promise<SimulatorStatus> {
       }),
     ),
   );
+
+  const finalizedCount = fetchedScores.filter(
+    (s) => s.status === "final",
+  ).length;
+  if (finalizedCount > 0) {
+    const recalc = await runStandingsRecalc();
+    log(
+      `Standings recalc: ${recalc.leaguesAffected} pair(s), ${recalc.picksRescored} pick(s) rescored`,
+    );
+  }
 
   // Jump to the next phase's start. Phases come back ordered by startDate,
   // so a simple index+1 lookup skips any between-phase gap without risking

--- a/lib/sync/nfl/live-scores.test.ts
+++ b/lib/sync/nfl/live-scores.test.ts
@@ -29,11 +29,18 @@ vi.mock("@/lib/nfl/scheduling", async (importOriginal) => {
   };
 });
 
+vi.mock("@/lib/sync/nfl/standings", () => ({
+  runStandingsRecalc: vi
+    .fn()
+    .mockResolvedValue({ leaguesAffected: 0, picksRescored: 0 }),
+}));
+
 const { getScorableEvents, updateEvent, getLockedEventIds } =
   await import("@/data/events");
 const { fetchEventScore } = await import("@/lib/espn/nfl/scores");
 const { isNflSeasonMonth, isGameWindowActive } =
   await import("@/lib/nfl/scheduling");
+const { runStandingsRecalc } = await import("@/lib/sync/nfl/standings");
 
 const mockGetScorableEvents = vi.mocked(getScorableEvents);
 const mockUpdateEvent = vi.mocked(updateEvent);
@@ -155,6 +162,9 @@ describe("runLiveScoresSync", () => {
       homeScore: 28,
       awayScore: 24,
     });
+    // §8.5: when any event finalizes, the live-scores sync must kick the
+    // standings recalc so scored picks flow into leaderboards.
+    expect(runStandingsRecalc).toHaveBeenCalledTimes(1);
   });
 
   it("handles mixed results — some final, some in-progress", async () => {
@@ -182,6 +192,22 @@ describe("runLiveScoresSync", () => {
     expect(result.eventsUpdated).toBe(3);
     expect(result.eventsFinalized).toBe(1);
     expect(mockUpdateEvent).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not recalc standings when nothing finalized", async () => {
+    const event = makeScorableEvent({
+      eventId: "event-3",
+      status: "in_progress",
+    });
+    mockGetScorableEvents.mockResolvedValue([event]);
+    mockFetchEventScore.mockResolvedValue(
+      makeScore({ status: "in_progress", homeScore: 10, awayScore: 7 }),
+    );
+
+    const result = await runLiveScoresSync(OCTOBER_SUNDAY);
+
+    expect(result.eventsFinalized).toBe(0);
+    expect(runStandingsRecalc).not.toHaveBeenCalled();
   });
 
   it("passes correct ESPN refs to fetchEventScore", async () => {

--- a/lib/sync/nfl/live-scores.ts
+++ b/lib/sync/nfl/live-scores.ts
@@ -6,6 +6,7 @@ import {
 import { getDataSourceByName } from "@/data/sports";
 import { fetchEventScore } from "@/lib/espn/nfl/scores";
 import { isGameWindowActive, isNflSeasonMonth } from "@/lib/nfl/scheduling";
+import { runStandingsRecalc } from "@/lib/sync/nfl/standings";
 
 export interface LiveScoresSyncResult {
   skipped: boolean;
@@ -112,8 +113,9 @@ export async function runLiveScoresSync(
   );
 
   if (eventsFinalized > 0) {
+    const recalc = await runStandingsRecalc();
     log(
-      `${eventsFinalized} events finalized — standings recalculation needed (PL-015)`,
+      `Recalculated ${recalc.leaguesAffected} (league, season) pair(s); ${recalc.picksRescored} pick(s) rescored`,
     );
   }
 

--- a/lib/sync/nfl/standings.test.ts
+++ b/lib/sync/nfl/standings.test.ts
@@ -1,0 +1,303 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { League } from "@/lib/db/schema/leagues";
+import type { LeagueMemberWithProfile } from "@/data/members";
+import type { PickWithEvent } from "@/data/picks";
+
+vi.mock("@/data/leagues", () => ({
+  getLeagueById: vi.fn(),
+}));
+
+vi.mock("@/data/members", () => ({
+  getLeagueMembersWithProfiles: vi.fn(),
+}));
+
+vi.mock("@/data/picks", () => ({
+  getLeagueSeasonPairsForEvent: vi.fn(),
+  getLeagueSeasonPairsWithUnscoredFinalPicks: vi.fn(),
+  getPicksForLeagueSeasonWithEvent: vi.fn(),
+  updatePickResults: vi.fn(),
+}));
+
+vi.mock("@/data/standings", () => ({
+  upsertLeagueStanding: vi.fn(),
+}));
+
+vi.mock("@/data/utils", () => ({
+  withTransaction: vi.fn(<T>(fn: (tx: unknown) => Promise<T>) => fn({})),
+}));
+
+import { getLeagueById } from "@/data/leagues";
+import { getLeagueMembersWithProfiles } from "@/data/members";
+import {
+  getLeagueSeasonPairsForEvent,
+  getLeagueSeasonPairsWithUnscoredFinalPicks,
+  getPicksForLeagueSeasonWithEvent,
+  updatePickResults,
+} from "@/data/picks";
+import { upsertLeagueStanding } from "@/data/standings";
+
+import { runStandingsRecalc, runStandingsRecalcForEvent } from "./standings";
+
+const LEAGUE_ID = "league-1";
+const SEASON_ID = "season-1";
+const EVENT_ID = "event-1";
+const HOME = "team-home";
+const AWAY = "team-away";
+const USER_A = "user-a";
+const USER_B = "user-b";
+const USER_FORMER = "user-former";
+
+const straightUpLeague: League = {
+  id: LEAGUE_ID,
+  sportsLeagueId: "nfl",
+  name: "Test",
+  imageUrl: null,
+  startSeasonType: "regular",
+  startWeekNumber: 1,
+  endSeasonType: "regular",
+  endWeekNumber: 18,
+  size: 10,
+  picksPerPhase: 2,
+  pickType: "straight_up",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+function member(userId: string): LeagueMemberWithProfile {
+  return {
+    id: `m-${userId}`,
+    leagueId: LEAGUE_ID,
+    userId,
+    role: "member",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    profile: {
+      id: `p-${userId}`,
+      userId,
+      username: userId,
+      name: userId,
+      avatarUrl: null,
+      role: "user",
+      setupComplete: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  };
+}
+
+function makePick(
+  id: string,
+  userId: string,
+  teamId: string,
+  existingResult: "win" | "loss" | "push" | null,
+): PickWithEvent {
+  return {
+    pick: {
+      id,
+      leagueId: LEAGUE_ID,
+      userId,
+      phaseId: "phase-1",
+      eventId: EVENT_ID,
+      teamId,
+      spreadAtLock: null,
+      pickResult: existingResult,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    event: {
+      id: EVENT_ID,
+      phaseId: "phase-1",
+      homeTeamId: HOME,
+      awayTeamId: AWAY,
+      startTime: new Date("2099-09-14T17:00:00Z"),
+      status: "final",
+      homeScore: 24,
+      awayScore: 17,
+      lockedAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getLeagueById).mockResolvedValue(straightUpLeague);
+  vi.mocked(getLeagueMembersWithProfiles).mockResolvedValue([
+    member(USER_A),
+    member(USER_B),
+  ]);
+  vi.mocked(getLeagueSeasonPairsWithUnscoredFinalPicks).mockResolvedValue([
+    { leagueId: LEAGUE_ID, seasonId: SEASON_ID },
+  ]);
+  vi.mocked(getLeagueSeasonPairsForEvent).mockResolvedValue([
+    { leagueId: LEAGUE_ID, seasonId: SEASON_ID },
+  ]);
+});
+
+describe("runStandingsRecalc", () => {
+  it("scores unscored picks and upserts standings", async () => {
+    vi.mocked(getPicksForLeagueSeasonWithEvent).mockResolvedValue([
+      makePick("p1", USER_A, HOME, null), // HOME wins → A: win
+      makePick("p2", USER_B, AWAY, null), // AWAY loses → B: loss
+    ]);
+
+    const result = await runStandingsRecalc();
+
+    expect(result.leaguesAffected).toBe(1);
+    expect(result.picksRescored).toBe(2);
+    expect(updatePickResults).toHaveBeenCalledWith(
+      [
+        { id: "p1", pickResult: "win" },
+        { id: "p2", pickResult: "loss" },
+      ],
+      {},
+    );
+    expect(upsertLeagueStanding).toHaveBeenCalledTimes(2);
+    expect(upsertLeagueStanding).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: USER_A,
+        wins: 1,
+        losses: 0,
+        pushes: 0,
+        points: 1,
+        rank: 1,
+      }),
+      {},
+    );
+    expect(upsertLeagueStanding).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: USER_B,
+        wins: 0,
+        losses: 1,
+        pushes: 0,
+        points: 0,
+        rank: 2,
+      }),
+      {},
+    );
+  });
+
+  it("does not re-update pickResults when the cached value already matches", async () => {
+    vi.mocked(getPicksForLeagueSeasonWithEvent).mockResolvedValue([
+      makePick("p1", USER_A, HOME, "win"),
+      makePick("p2", USER_B, AWAY, "loss"),
+    ]);
+
+    const result = await runStandingsRecalc();
+
+    expect(result.picksRescored).toBe(0);
+    expect(updatePickResults).toHaveBeenCalledWith([], {});
+    expect(upsertLeagueStanding).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-scores cleared picks from null back to the computed result", async () => {
+    // A pick stored as null (e.g. freshly created, never scored) gets
+    // re-scored against the current event state on the next recalc.
+    vi.mocked(getPicksForLeagueSeasonWithEvent).mockResolvedValue([
+      makePick("p1", USER_A, HOME, null),
+    ]);
+
+    const result = await runStandingsRecalc();
+
+    expect(updatePickResults).toHaveBeenCalledWith(
+      [{ id: "p1", pickResult: "win" }],
+      {},
+    );
+    expect(result.picksRescored).toBe(1);
+  });
+
+  it("lazy-inits a zero standing for members without scored picks", async () => {
+    // Only A has a pick; B should still get a rank-1 zero standing.
+    vi.mocked(getPicksForLeagueSeasonWithEvent).mockResolvedValue([
+      makePick("p1", USER_A, HOME, null),
+    ]);
+
+    await runStandingsRecalc();
+
+    expect(upsertLeagueStanding).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: USER_B,
+        wins: 0,
+        losses: 0,
+        pushes: 0,
+        points: 0,
+        rank: 2,
+      }),
+      {},
+    );
+  });
+
+  it("preserves picks from a former member in the totals (§4.3)", async () => {
+    // USER_FORMER isn't in the members list but has picks. Their totals
+    // should still be computed and their standing row upserted, matching
+    // §4.3's "removed member's historical picks and standings remain".
+    vi.mocked(getLeagueMembersWithProfiles).mockResolvedValue([member(USER_A)]);
+    vi.mocked(getPicksForLeagueSeasonWithEvent).mockResolvedValue([
+      makePick("p1", USER_A, HOME, null),
+      makePick("p2", USER_FORMER, HOME, null),
+    ]);
+
+    await runStandingsRecalc();
+
+    expect(upsertLeagueStanding).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: USER_FORMER,
+        wins: 1,
+        points: 1,
+      }),
+      {},
+    );
+  });
+
+  it("no pairs → no work", async () => {
+    vi.mocked(getLeagueSeasonPairsWithUnscoredFinalPicks).mockResolvedValue([]);
+    const result = await runStandingsRecalc();
+    expect(result).toEqual({ leaguesAffected: 0, picksRescored: 0 });
+    expect(upsertLeagueStanding).not.toHaveBeenCalled();
+  });
+});
+
+describe("runStandingsRecalcForEvent", () => {
+  it("only recalculates leagues that have picks on the event", async () => {
+    vi.mocked(getLeagueSeasonPairsForEvent).mockResolvedValue([
+      { leagueId: LEAGUE_ID, seasonId: SEASON_ID },
+    ]);
+    vi.mocked(getPicksForLeagueSeasonWithEvent).mockResolvedValue([
+      makePick("p1", USER_A, HOME, null),
+    ]);
+
+    const result = await runStandingsRecalcForEvent(EVENT_ID);
+
+    expect(getLeagueSeasonPairsForEvent).toHaveBeenCalledWith(EVENT_ID);
+    expect(result.leaguesAffected).toBe(1);
+    expect(upsertLeagueStanding).toHaveBeenCalled();
+  });
+
+  it("re-scores picks after an admin clears their pickResult (admin override path)", async () => {
+    // Mirrors the admin-override flow: pickResult was cleared (null) and
+    // the scoped recalc re-derives it from the event's current score.
+    vi.mocked(getLeagueSeasonPairsForEvent).mockResolvedValue([
+      { leagueId: LEAGUE_ID, seasonId: SEASON_ID },
+    ]);
+    vi.mocked(getPicksForLeagueSeasonWithEvent).mockResolvedValue([
+      makePick("p1", USER_A, HOME, null),
+    ]);
+
+    const result = await runStandingsRecalcForEvent(EVENT_ID);
+
+    expect(updatePickResults).toHaveBeenCalledWith(
+      [{ id: "p1", pickResult: "win" }],
+      {},
+    );
+    expect(result.picksRescored).toBe(1);
+  });
+
+  it("no-ops when no picks exist on the event", async () => {
+    vi.mocked(getLeagueSeasonPairsForEvent).mockResolvedValue([]);
+    const result = await runStandingsRecalcForEvent(EVENT_ID);
+    expect(result).toEqual({ leaguesAffected: 0, picksRescored: 0 });
+    expect(getPicksForLeagueSeasonWithEvent).not.toHaveBeenCalled();
+  });
+});

--- a/lib/sync/nfl/standings.ts
+++ b/lib/sync/nfl/standings.ts
@@ -1,0 +1,131 @@
+import { getLeagueById } from "@/data/leagues";
+import { getLeagueMembersWithProfiles } from "@/data/members";
+import {
+  getLeagueSeasonPairsForEvent,
+  getLeagueSeasonPairsWithUnscoredFinalPicks,
+  getPicksForLeagueSeasonWithEvent,
+  updatePickResults,
+  type LeagueSeasonPair,
+  type PickResultUpdate,
+} from "@/data/picks";
+import { upsertLeagueStanding } from "@/data/standings";
+import { withTransaction } from "@/data/utils";
+import type { PickResult } from "@/lib/db/schema/picks";
+import {
+  calculatePickResult,
+  calculateStandingsPoints,
+  denseRank,
+} from "@/lib/nfl/scoring";
+
+export interface StandingsRecalcResult {
+  leaguesAffected: number;
+  picksRescored: number;
+}
+
+export async function runStandingsRecalc(): Promise<StandingsRecalcResult> {
+  const pairs = await getLeagueSeasonPairsWithUnscoredFinalPicks();
+  return recalcPairs(pairs);
+}
+
+export async function runStandingsRecalcForEvent(
+  eventId: string,
+): Promise<StandingsRecalcResult> {
+  const pairs = await getLeagueSeasonPairsForEvent(eventId);
+  return recalcPairs(pairs);
+}
+
+async function recalcPairs(
+  pairs: LeagueSeasonPair[],
+): Promise<StandingsRecalcResult> {
+  // Serial across pairs so a burst of finalized events doesn't open a
+  // flurry of concurrent transactions. Each pair is already parallelized
+  // internally across member upserts.
+  let picksRescored = 0;
+  for (const { leagueId, seasonId } of pairs) {
+    picksRescored += await recalcLeagueSeason(leagueId, seasonId);
+  }
+  return { leaguesAffected: pairs.length, picksRescored };
+}
+
+async function recalcLeagueSeason(
+  leagueId: string,
+  seasonId: string,
+): Promise<number> {
+  const [league, seasonPicks, members] = await Promise.all([
+    getLeagueById(leagueId),
+    getPicksForLeagueSeasonWithEvent(leagueId, seasonId),
+    getLeagueMembersWithProfiles(leagueId),
+  ]);
+  if (!league) return 0;
+
+  // Re-score every pick in the (league, season). Scoring is deterministic
+  // from the event's current state, so we always recompute — this is the
+  // §8.5 step-4 "full integrity check" pass rather than an incremental
+  // delta. Only persist rows whose stored pickResult differs from the
+  // computed one (covers both "unscored → scored" and "admin edit changed
+  // the result").
+  const updates: PickResultUpdate[] = [];
+  const resultsByUser = new Map<string, (PickResult | null)[]>();
+  for (const member of members) {
+    resultsByUser.set(member.userId, []);
+  }
+  for (const { pick, event } of seasonPicks) {
+    const newResult = calculatePickResult(pick, event, league.pickType);
+    if (newResult !== pick.pickResult) {
+      updates.push({ id: pick.id, pickResult: newResult });
+    }
+    const bucket = resultsByUser.get(pick.userId);
+    if (bucket) {
+      bucket.push(newResult);
+    } else {
+      // Historical picks from a former member (removed mid-season) still
+      // count toward §4.3 "historical picks and standings remain" — keep
+      // them in the totals even though the user isn't in `members` now.
+      resultsByUser.set(pick.userId, [newResult]);
+    }
+  }
+
+  // Totals per user (lazy-init §8.6 zero rows for members without any
+  // scored picks — guarantees everyone has a standing to rank).
+  const totalsByUser = new Map(
+    Array.from(resultsByUser, ([userId, results]) => [
+      userId,
+      calculateStandingsPoints(results),
+    ]),
+  );
+
+  // Dense ranking by points (§8.4).
+  const ranked = denseRank(
+    Array.from(totalsByUser, ([userId, totals]) => ({
+      userId,
+      ...totals,
+    })),
+    (entry) => entry.points,
+  );
+
+  // Atomic per-pair write: pick result updates + standings upserts land
+  // together so a partial failure doesn't leave standings out of sync
+  // with the pick results that drove them.
+  await withTransaction(async (tx) => {
+    await updatePickResults(updates, tx);
+    await Promise.all(
+      ranked.map(({ entry, rank }) =>
+        upsertLeagueStanding(
+          {
+            leagueId,
+            userId: entry.userId,
+            seasonId,
+            wins: entry.wins,
+            losses: entry.losses,
+            pushes: entry.pushes,
+            points: entry.points,
+            rank,
+          },
+          tx,
+        ),
+      ),
+    );
+  });
+
+  return updates.length;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,3 @@
 export type ActionResult<T = void> =
   | { success: true; data: T }
-  | { success: false; error: string };
+  | { success: false; error: string; code?: string };

--- a/lib/validators/picks.ts
+++ b/lib/validators/picks.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+import { PICKS_PER_PHASE_MAX } from "@/lib/validators/leagues";
+
+const pickSelectionSchema = z.object({
+  eventId: z.string().uuid({ error: "Invalid game id." }),
+  teamId: z.string().uuid({ error: "Invalid team id." }),
+});
+
+export const submitPicksSchema = z.object({
+  leagueId: z.string().uuid({ error: "Invalid league id." }),
+  phaseId: z.string().uuid({ error: "Invalid phase id." }),
+  picks: z
+    .array(pickSelectionSchema)
+    .min(1, { message: "Pick at least one game." })
+    .max(PICKS_PER_PHASE_MAX, {
+      message: `No more than ${PICKS_PER_PHASE_MAX} picks per submission.`,
+    }),
+});
+
+export type SubmitPicksInput = z.input<typeof submitPicksSchema>;
+export type SubmitPicksOutput = z.output<typeof submitPicksSchema>;

--- a/lib/validators/picks.ts
+++ b/lib/validators/picks.ts
@@ -5,6 +5,11 @@ import { PICKS_PER_PHASE_MAX } from "@/lib/validators/leagues";
 const pickSelectionSchema = z.object({
   eventId: z.string().uuid({ error: "Invalid game id." }),
   teamId: z.string().uuid({ error: "Invalid team id." }),
+  // The spread the client saw for the picked team at submit time. Optional
+  // at the schema level because Straight Up leagues don't use spreads; the
+  // action requires it on ATS leagues and rejects with code STALE_ODDS if
+  // it's missing or diverges from the current DB spread.
+  expectedSpread: z.number().nullable().optional(),
 });
 
 export const submitPicksSchema = z.object({

--- a/work/Backlog.md
+++ b/work/Backlog.md
@@ -286,7 +286,7 @@ Admin Overrides is a parallel track off Simulator — it reuses the admin gate a
   - Dense ranking
   - Season history (prior season standings preserved)
 
-- [~] PL-015: Standings recalculation service (BUSINESS_SPEC §8.5, BACKGROUND_JOBS §5)
+- [x] PL-015: Standings recalculation service (BUSINESS_SPEC §8.5, BACKGROUND_JOBS §5)
   - Re-slotted from Section 2 — depends on picks (PL-028), pick scoring (PL-030), standings schema (PL-031).
   - lib/sync/nfl/standings.ts
   - Score unscored picks, recalculate totals, recompute dense rankings

--- a/work/Backlog.md
+++ b/work/Backlog.md
@@ -10,11 +10,11 @@
 
 | Status      | Count  |
 | ----------- | ------ |
-| Complete    | 32     |
-| In Progress | 8      |
+| Complete    | 41     |
+| In Progress | 0      |
 | Blocked     | 0      |
-| Pending     | 0      |
-| **Total**   | **40** |
+| Pending     | 7      |
+| **Total**   | **48** |
 
 ---
 

--- a/work/Backlog.md
+++ b/work/Backlog.md
@@ -253,6 +253,7 @@ Admin Overrides is a parallel track off Simulator — it reuses the admin gate a
 
 - [x] PL-027: Phase picks view (BUSINESS_SPEC §6, §10, §12.4-12.5)
   - **Absorbs PL-032** — phase navigation + historical viewing ship together in this story (epic decision).
+  - **Follow-up**: after lock, My Picks filters the event list down to the games the viewer picked (other games are noise on that surface). League Picks keeps the full schedule so member cards are comparable.
   - Phase/event data display: teams, odds, scores, lock status
   - Phase navigation (prev/next) + historical picks/results view
   - Current phase resolution logic (lib/nfl/leagues.ts#selectLeagueCurrentPhase)
@@ -261,6 +262,7 @@ Admin Overrides is a parallel track off Simulator — it reuses the admin gate a
 
 - [x] PL-028: Pick submission — straight up + ATS (BUSINESS_SPEC §7.1-7.2, §9.3)
   - **Absorbs PL-029** — one submission action handles both pick types (epic decision).
+  - **Current-phase-only submission (follow-up to the initial PR)**: `submitPicksAction` rejects any phaseId that isn't the phase §6.3 resolves to — no past, no future. My-picks UI mirrors it by rendering future phases view-only (no submit form). Codified in §6.4 / §7.1 #2.
   - lib/validators/picks.ts — SubmitPicksSchema
   - lib/nfl/leagues.ts — isPickLocked(phase, event, now)
   - actions/picks.ts — submitPicks action (upsert, preserves already-locked picks)
@@ -285,6 +287,7 @@ Admin Overrides is a parallel track off Simulator — it reuses the admin gate a
   - Standings tab: sortable table with rank, player, points, W/L/P
   - Dense ranking
   - Season history (prior season standings preserved)
+  - **Follow-up**: My Picks header and League Picks member cards now show a per-phase "weekly" row (W-L-P + points + rank) alongside overall — the weekly view uses `calculateWeeklyStandings(picks, userIds)` in `lib/nfl/scoring.ts`. League Picks sorts members by weekly points desc with overall points as tiebreaker (best this-week first). Weekly row is hidden until at least one pick in the phase is scored.
 
 - [x] PL-015: Standings recalculation service (BUSINESS_SPEC §8.5, BACKGROUND_JOBS §5)
   - Re-slotted from Section 2 — depends on picks (PL-028), pick scoring (PL-030), standings schema (PL-031).
@@ -324,6 +327,19 @@ Admin Overrides is a parallel track off Simulator — it reuses the admin gate a
 - [ ] PL-055: Pick stats + trends
   - Advanced stats to help users make informed picks
   - Historical pick performance data
+
+- [ ] PL-080: Phase-over-phase standings delta (BUSINESS_SPEC §8.3-8.4)
+  - On the standings tab, show each member's rank change vs. the end of the previous phase — up/down/flat arrow with magnitude.
+  - Needs historical standings-per-phase: either persist a snapshot at the end of each recalc (new `league_standings_history` table keyed by phase), or compute on demand by replaying scored picks up to phase N-1.
+  - Inspiration: the BracketsBall legacy app's March Madness standings use this pattern.
+
+- [ ] PL-081: Live game period + clock (BUSINESS_SPEC §10.3, §10.5, §11.1)
+  - Spec says in-progress games should display current period + game clock alongside the "LIVE" chip; today the schema doesn't persist those fields and the UI renders only the chip + running score.
+  - Schema: add `period` (smallint) and `clock` (text) nullable columns to `events`; migration.
+  - ESPN client (`lib/espn/nfl/scores.ts`): parse `period` + `clock` off the scoreboard response.
+  - Sync (`lib/sync/nfl/live-scores.ts`): thread both fields through `updateEvent` on each poll.
+  - UI (`components/picks/event-pick-card.tsx`): extend `EventStatusLine`'s `in_progress` branch to render e.g. `LIVE · Q3 · 4:12`.
+  - Not blocking MVP — scoring and ranking don't depend on these fields, so it's a polish item.
 
 - [x] PL-056: League season state badge (BUSINESS_SPEC §3.7)
   - lib/nfl/leagues.ts — getLeagueSeasonState(phases, format, now) → "upcoming" | "in_progress" | "complete"

--- a/work/Backlog.md
+++ b/work/Backlog.md
@@ -259,7 +259,7 @@ Admin Overrides is a parallel track off Simulator — it reuses the admin gate a
   - Live score display (not started / in progress / final indicators)
   - **Use `getAppNow()`** (lib/simulator) for current-phase resolution + lock status so the simulator controls the view state.
 
-- [~] PL-028: Pick submission — straight up + ATS (BUSINESS_SPEC §7.1-7.2, §9.3)
+- [x] PL-028: Pick submission — straight up + ATS (BUSINESS_SPEC §7.1-7.2, §9.3)
   - **Absorbs PL-029** — one submission action handles both pick types (epic decision).
   - lib/validators/picks.ts — SubmitPicksSchema
   - lib/nfl/leagues.ts — isPickLocked(phase, event, now)
@@ -270,8 +270,8 @@ Admin Overrides is a parallel track off Simulator — it reuses the admin gate a
   - ATS spread frozen into pick at submission time (spreadAtLock field)
   - **Use `getAppNow()`** in the action so simulator advancement flips pick locks.
 
-- [~] PL-029: Pick submission — against the spread (BUSINESS_SPEC §7.1, §9.3)
-  - **Absorbed into PL-028** — will close with PL-028's commit.
+- [x] PL-029: Pick submission — against the spread (BUSINESS_SPEC §7.1, §9.3)
+  - **Absorbed into PL-028** — shipped with PL-028's commit.
 
 - [~] PL-030: Pick results calculation (BUSINESS_SPEC §8.1-8.2)
   - lib/nfl/scoring.ts — calculatePickResult(), calculateStandingsPoints()

--- a/work/Backlog.md
+++ b/work/Backlog.md
@@ -273,7 +273,7 @@ Admin Overrides is a parallel track off Simulator — it reuses the admin gate a
 - [x] PL-029: Pick submission — against the spread (BUSINESS_SPEC §7.1, §9.3)
   - **Absorbed into PL-028** — shipped with PL-028's commit.
 
-- [~] PL-030: Pick results calculation (BUSINESS_SPEC §8.1-8.2)
+- [x] PL-030: Pick results calculation (BUSINESS_SPEC §8.1-8.2)
   - lib/nfl/scoring.ts — calculatePickResult(), calculateStandingsPoints()
   - Straight up: compare scores
   - ATS: apply frozen spread, compare adjusted scores

--- a/work/Backlog.md
+++ b/work/Backlog.md
@@ -251,7 +251,7 @@ Admin Overrides is a parallel track off Simulator — it reuses the admin gate a
 
 ## 6. Picks & Scoring (depends on: Leagues + Simulator ready for testing)
 
-- [~] PL-027: Phase picks view (BUSINESS_SPEC §6, §10, §12.4-12.5)
+- [x] PL-027: Phase picks view (BUSINESS_SPEC §6, §10, §12.4-12.5)
   - **Absorbs PL-032** — phase navigation + historical viewing ship together in this story (epic decision).
   - Phase/event data display: teams, odds, scores, lock status
   - Phase navigation (prev/next) + historical picks/results view
@@ -295,8 +295,8 @@ Admin Overrides is a parallel track off Simulator — it reuses the admin gate a
   - **Admin event edits clear `pickResult` on affected picks** — `updateEventAction` (PL-073, shipped) must null out `pickResult` for every pick on the event whenever scores or status change on a `final` event (or status flips away from `final`). The next recalc run then re-scores them via step 2 of §8.5.
   - **Cron-driven entry point uses real `new Date()`**. The simulator wires its own path through `advancePhase` — this job doesn't need `getAppNow()` because its triggers (cron + live-scores sync) are real-world events. Simulator already exercises this code via `lib/sync/nfl/live-scores.ts`.
 
-- [~] PL-032: Phase navigation (BUSINESS_SPEC §6.3-6.4)
-  - **Absorbed into PL-027** — will close with PL-027's commit.
+- [x] PL-032: Phase navigation (BUSINESS_SPEC §6.3-6.4)
+  - **Absorbed into PL-027** — shipped with PL-027's commit.
 
 - [~] PL-033: League picks view (BUSINESS_SPEC §7.3, §12.4)
   - Before lock: "picks will be visible after deadline" message

--- a/work/Backlog.md
+++ b/work/Backlog.md
@@ -281,7 +281,7 @@ Admin Overrides is a parallel track off Simulator — it reuses the admin gate a
   - `calculatePickResult` is deterministic from the event's current score — no caching assumptions beyond the stored `pickResult` field, which is invalidated on admin event edits (see PL-015)
   - Tests for all scoring edge cases
 
-- [~] PL-031: Standings + leaderboard UI (BUSINESS_SPEC §8.3-8.4, §12.4)
+- [x] PL-031: Standings + leaderboard UI (BUSINESS_SPEC §8.3-8.4, §12.4)
   - Standings tab: sortable table with rank, player, points, W/L/P
   - Dense ranking
   - Season history (prior season standings preserved)

--- a/work/Backlog.md
+++ b/work/Backlog.md
@@ -11,9 +11,9 @@
 | Status      | Count  |
 | ----------- | ------ |
 | Complete    | 32     |
-| In Progress | 0      |
+| In Progress | 8      |
 | Blocked     | 0      |
-| Pending     | 8      |
+| Pending     | 0      |
 | **Total**   | **40** |
 
 ---
@@ -251,27 +251,29 @@ Admin Overrides is a parallel track off Simulator — it reuses the admin gate a
 
 ## 6. Picks & Scoring (depends on: Leagues + Simulator ready for testing)
 
-- [ ] PL-027: Phase picks view (BUSINESS_SPEC §6, §10, §12.4-12.5)
+- [~] PL-027: Phase picks view (BUSINESS_SPEC §6, §10, §12.4-12.5)
+  - **Absorbs PL-032** — phase navigation + historical viewing ship together in this story (epic decision).
   - Phase/event data display: teams, odds, scores, lock status
-  - Phase navigation (prev/next)
-  - Current phase resolution logic (lib/nfl/scheduling.ts)
+  - Phase navigation (prev/next) + historical picks/results view
+  - Current phase resolution logic (lib/nfl/leagues.ts#selectLeagueCurrentPhase)
   - Live score display (not started / in progress / final indicators)
   - **Use `getAppNow()`** (lib/simulator) for current-phase resolution + lock status so the simulator controls the view state.
 
-- [ ] PL-028: Pick submission — straight up (BUSINESS_SPEC §7.1-7.2)
+- [~] PL-028: Pick submission — straight up + ATS (BUSINESS_SPEC §7.1-7.2, §9.3)
+  - **Absorbs PL-029** — one submission action handles both pick types (epic decision).
   - lib/validators/picks.ts — SubmitPicksSchema
-  - lib/nfl/scheduling.ts — isGameStarted(now?), isPhasePastLockTime(now?)
-  - actions/picks.ts — submitPicks action
-  - Interactive pick UI: clickable team cards, toggle selection, progress counter
+  - lib/nfl/leagues.ts — isPickLocked(phase, event, now)
+  - actions/picks.ts — submitPicks action (upsert, preserves already-locked picks)
+  - Interactive pick UI: clickable team cards, toggle selection, progress counter, spread display for ATS leagues
   - Pick lock enforcement: phase lock time + individual game kickoff
   - Required pick count: min(picksPerPhase, unstartedGames)
-  - **Use `getAppNow()`** in the action — pass it into `isGameStarted` / `isPhasePastLockTime` so simulator advancement flips pick locks.
+  - ATS spread frozen into pick at submission time (spreadAtLock field)
+  - **Use `getAppNow()`** in the action so simulator advancement flips pick locks.
 
-- [ ] PL-029: Pick submission — against the spread (BUSINESS_SPEC §7.1, §9.3)
-  - Extends PL-028 with spread display and spread snapshot at submission
-  - Spread frozen into pick at submission time (spreadAtLock field)
+- [~] PL-029: Pick submission — against the spread (BUSINESS_SPEC §7.1, §9.3)
+  - **Absorbed into PL-028** — will close with PL-028's commit.
 
-- [ ] PL-030: Pick results calculation (BUSINESS_SPEC §8.1-8.2)
+- [~] PL-030: Pick results calculation (BUSINESS_SPEC §8.1-8.2)
   - lib/nfl/scoring.ts — calculatePickResult(), calculateStandingsPoints()
   - Straight up: compare scores
   - ATS: apply frozen spread, compare adjusted scores
@@ -279,12 +281,12 @@ Admin Overrides is a parallel track off Simulator — it reuses the admin gate a
   - `calculatePickResult` is deterministic from the event's current score — no caching assumptions beyond the stored `pickResult` field, which is invalidated on admin event edits (see PL-015)
   - Tests for all scoring edge cases
 
-- [ ] PL-031: Standings + leaderboard UI (BUSINESS_SPEC §8.3-8.4, §12.4)
+- [~] PL-031: Standings + leaderboard UI (BUSINESS_SPEC §8.3-8.4, §12.4)
   - Standings tab: sortable table with rank, player, points, W/L/P
   - Dense ranking
   - Season history (prior season standings preserved)
 
-- [ ] PL-015: Standings recalculation service (BUSINESS_SPEC §8.5, BACKGROUND_JOBS §5)
+- [~] PL-015: Standings recalculation service (BUSINESS_SPEC §8.5, BACKGROUND_JOBS §5)
   - Re-slotted from Section 2 — depends on picks (PL-028), pick scoring (PL-030), standings schema (PL-031).
   - lib/sync/nfl/standings.ts
   - Score unscored picks, recalculate totals, recompute dense rankings
@@ -293,13 +295,10 @@ Admin Overrides is a parallel track off Simulator — it reuses the admin gate a
   - **Admin event edits clear `pickResult` on affected picks** — `updateEventAction` (PL-073, shipped) must null out `pickResult` for every pick on the event whenever scores or status change on a `final` event (or status flips away from `final`). The next recalc run then re-scores them via step 2 of §8.5.
   - **Cron-driven entry point uses real `new Date()`**. The simulator wires its own path through `advancePhase` — this job doesn't need `getAppNow()` because its triggers (cron + live-scores sync) are real-world events. Simulator already exercises this code via `lib/sync/nfl/live-scores.ts`.
 
-- [ ] PL-032: Phase navigation (BUSINESS_SPEC §6.3-6.4)
-  - Prev/next phase browsing
-  - Historical picks and results view
-  - Current phase auto-detection
-  - **Use `getAppNow()`** for the "what phase am I on right now?" landing default.
+- [~] PL-032: Phase navigation (BUSINESS_SPEC §6.3-6.4)
+  - **Absorbed into PL-027** — will close with PL-027's commit.
 
-- [ ] PL-033: League picks view (BUSINESS_SPEC §7.3, §12.4)
+- [~] PL-033: League picks view (BUSINESS_SPEC §7.3, §12.4)
   - Before lock: "picks will be visible after deadline" message
   - After lock: collapsible cards per member with picks, record, points
 

--- a/work/Backlog.md
+++ b/work/Backlog.md
@@ -298,7 +298,7 @@ Admin Overrides is a parallel track off Simulator — it reuses the admin gate a
 - [x] PL-032: Phase navigation (BUSINESS_SPEC §6.3-6.4)
   - **Absorbed into PL-027** — shipped with PL-027's commit.
 
-- [~] PL-033: League picks view (BUSINESS_SPEC §7.3, §12.4)
+- [x] PL-033: League picks view (BUSINESS_SPEC §7.3, §12.4)
   - Before lock: "picks will be visible after deadline" message
   - After lock: collapsible cards per member with picks, record, points
 

--- a/work/tasks/PL-015.md
+++ b/work/tasks/PL-015.md
@@ -1,0 +1,80 @@
+---
+id: PL-015
+title: Standings recalculation service
+status: complete
+---
+
+## Summary
+
+Wires scoring + standings together. `lib/sync/nfl/standings.ts` exports two entry points:
+
+- `runStandingsRecalc()` — full sweep. Finds every `(leagueId, seasonId)` pair with at least one unscored pick whose event is final, then recomputes that pair's pick results, totals, and ranks. Called from `runLiveScoresSync` (cron) and `advancePhase` (simulator) when any event finalizes.
+- `runStandingsRecalcForEvent(eventId)` — scoped. Finds only the pairs that have picks on the given event, recomputes those. Called from `updateEventAction` (admin override) immediately after the event write + `clearPickResultsForEvent`.
+
+Each pair's recalc is wrapped in a transaction so pick-result updates and standings upserts land atomically.
+
+## Business Spec Coverage
+
+- §8.5 step 1 — unscored-on-final filter lives in `getLeagueSeasonPairsWithUnscoredFinalPicks`.
+- §8.5 step 2 — `calculatePickResult` per pick, persisted by `updatePickResults` only when the stored value differs.
+- §8.5 step 3 — `calculateStandingsPoints` aggregates per user from the in-memory results map.
+- §8.5 step 4 — every pick in the (league, season) is re-scored on each run, not just the unscored ones. This is the "full integrity check" path.
+- §8.5 admin edit — `updateEventAction` nulls every pick on the event via `clearPickResultsForEvent`, then re-scores them against the corrected event via the scoped recalc.
+- §8.6 — members without any scored picks still get a zero-init standing row (lazy creation in the upsert loop).
+- §8.4 — dense ranking applied via the `denseRank` helper from PL-030.
+- §4.3 — picks from former members (those not in `getLeagueMembersWithProfiles`) are still scored and their standings upserted. Confirmed by test.
+- §10.2 — `final` is authoritative: `calculatePickResult` returns null for non-final events, so unfinished events don't perturb the totals.
+- BACKGROUND_JOBS §5 — live-scores sync kicks `runStandingsRecalc()` after any event finalizes.
+
+## Decisions
+
+- **Two entry points, one orchestrator.** The full sweep and the scoped-by-event path both route into the same `recalcLeagueSeason(leagueId, seasonId)` core. Two call shapes, zero duplicated scoring/ranking logic.
+- **Per-pair transaction, not per-run.** A single league's recalc needs to stay consistent (pick results and standings match), but different leagues' recalcs are independent. Wrapping each `(league, season)` separately lets one bad league fail in isolation.
+- **Full rescoring on every run, not just the unscored ones.** §8.5 step 4 explicitly asks for a recompute-from-all-scored-picks integrity pass. Doing it every time is cheap relative to the rest of the work and catches any drift (e.g. admin corrections that landed before a recalc ran).
+- **Persist only changed pick results.** `updatePickResults` is bucketed by the new pickResult value so we make at most four SQL statements per pair even when many picks change. Unchanged rows are skipped.
+- **Admin override: clear then recalc.** `updateEventAction` clears pick results before calling the recalc so a recalc failure leaves the event's picks "unscored" rather than carrying a stale cached result. The scoped recalc refills them from the corrected event state.
+- **Failure path guard on admin override.** When `updateEvent` throws (e.g. event not found), we don't clear pick results or run the recalc. Confirmed by test — otherwise an unrelated failure would silently wipe pick history on picks for this event.
+- **Parallel member upserts inside a pair.** Per-member `upsertLeagueStanding` calls inside one pair's transaction fire via `Promise.all`. Serial pairs (to avoid flooding Postgres with concurrent transactions in a cron burst), parallel within a pair.
+- **Data helpers scoped tightly.** `getPicksForLeagueSeasonWithEvent` joins picks → events → phases filtered by `(leagueId, phases.seasonId)`. `getLeagueSeasonPairsForEvent` is a distinct-select on picks + phases for one event. `getLeagueSeasonPairsWithUnscoredFinalPicks` does the same distinct-select gated by `pickResult IS NULL AND events.status = 'final'`.
+- **Serial loop across pairs, documented.** Left a comment at the `recalcPairs` loop explaining why it isn't `Promise.all` so a future reader doesn't "optimize" it blind.
+
+## Deviations from the Story
+
+- None in scope. The story's "admin event edits clear pickResult" note is implemented as designed (cleared first, then scoped recalc).
+
+## Notable / Gotchas
+
+- **Live-scores sync recalc is broader than BACKGROUND_JOBS §5 literally reads.** §5 says "recalc for all leagues that have picks on those events." Implementation does the full `runStandingsRecalc()` sweep, which is a superset (includes those leagues plus any other unscored-final leftovers). Spec-tracer flagged this as "a feature, not a bug" — aligns with §8.5 step 4's full-integrity framing. If live-scores ever gets chatty enough that the sweep shows up in profiles, switch to a per-finalized-event loop calling `runStandingsRecalcForEvent(eventId)`.
+- **`upsertLeagueStanding` defaults (`?? 0`, `?? 1`) are defensive.** The `StandingTotals` shape always populates every field, so the fallbacks only fire for extreme/future callers passing a partial payload. Kept them to match the existing `insertLeagueStanding` idiom in the codebase.
+- **No tests for `getPicksForLeagueSeasonWithEvent` / `updatePickResults` / etc.** Thin Drizzle wrappers — mocked at import boundaries in `standings.test.ts` per `rules/testing.md`.
+- **Serial pairs loop means a throw on pair N blocks pairs N+1..**. Acceptable because each pair's failure is atomic (transaction rollback) and a hard error propagates up to the caller (cron, simulator, admin action) for visibility. If we ever want best-effort per-pair, wrap the inner call in a try/catch and surface failures in the result object.
+- **Admin override unconditionally runs the recalc after any successful event update**, even no-op edits (pure re-lock, only `startTime` changed, etc.). Cheap for leagues with few picks; optimizable later by diffing before clearing.
+- **Lazy standings init via `upsertLeagueStanding`.** §8.6's initial zero row is still written by `insertLeagueStanding` on join (PL-020/PL-023); the upsert in the recalc is the fallback that guarantees a row exists for every member by the time ranks are computed.
+
+## Follow-ups
+
+- **BACKGROUND_JOBS §5 scope note.** Either update the spec wording to match the current "full integrity sweep" behavior or switch the live-scores caller to the per-event scoped path. No behavioral bug today.
+- **Observability.** The recalc logs via `console.log` at both call sites; a structured metric (leagues affected / picks rescored / duration) would make it easier to catch regressions once Sentry is wired (PL-050).
+- **Optional N+1 tightening.** Parallelizing the pairs loop (e.g. with a concurrency cap) would help if a cron run ever touches many leagues at once. Keep the per-pair transaction even if pairs go parallel.
+
+## Code-reviewer findings
+
+No blockers. Non-blockers addressed before commit:
+
+- `getStandingsForLeagueSeason` dead code → removed (PL-031 will add back if needed).
+- Per-member upsert loop was serial → now `Promise.all` inside the per-pair transaction.
+- Missing per-pair transaction → added `withTransaction` wrapping pick updates + standing upserts.
+- Admin override tests didn't assert `clearPickResultsForEvent` / `runStandingsRecalcForEvent` were called → added tests for success and failure paths.
+- `live-scores.test.ts` didn't assert recalc on finalize / skipped when nothing finalized → added both.
+- `simulator.test.ts` didn't assert recalc on finalize → added.
+- Misnamed admin-path test in `standings.test.ts` → renamed + added a companion test driving `runStandingsRecalcForEvent`.
+
+Deferred non-blockers:
+
+- Conditional skip of recalc in `updateEventAction` when the edit didn't affect scoring fields — optimization, out of scope.
+- Lifting the `lib/sync/` exception note for pure-DB orchestration into `ARCHITECTURE.md` — doc hygiene.
+- Batched multi-row `upsertLeagueStanding` via Drizzle's `excluded.*` — awkward with per-row ranks; left as-is.
+
+## Spec-tracer findings
+
+No blocker divergences. One non-blocker: the live-scores call uses the full sweep rather than the per-event scoped path (strict superset of what §5 literally asks for). Noted in Follow-ups.

--- a/work/tasks/PL-027.md
+++ b/work/tasks/PL-027.md
@@ -55,11 +55,13 @@ Also introduces the `picks` schema (migration 0009) with all fields every epic s
 ## Code-reviewer findings
 
 Three blockers fixed before commit:
+
 1. Non-deterministic odds dedupe + missing sportsbook attribution → replaced `getOddsForEvents` with `getOddsForEventsWithSportsbook`, deterministic `Map.set-if-absent` dedupe, attribution rendered on ATS cards.
 2. `Intl.DateTimeFormat(undefined, …)` for server-rendered dates (TZ mismatch / hydration risk) → swapped to `formatInTimeZone` with `America/New_York` on both the banner and the event card.
 3. Raw `now >= phase.pickLockTime` in the page (business logic in a page) → extracted `isPhaseLocked(phase, now)` helper in `lib/nfl/leagues.ts`, with tests; page delegates.
 
 Non-blockers surfaced:
+
 - `getPicksForLeaguePhase` `orderBy(createdAt)` is inert for the current Map-based consumer (kept in case PL-028/PL-033 want a submission timeline).
 - Page re-fetches season/phases the layout already loaded (see Gotchas).
 - `asChild`+`disabled` on the phase-nav Button mixes two Radix modes; the pointer-events-none fallback keeps it correct but a cleaner pattern would split disabled/enabled branches. Deferred.

--- a/work/tasks/PL-027.md
+++ b/work/tasks/PL-027.md
@@ -1,0 +1,69 @@
+---
+id: PL-027
+title: Phase picks view (absorbs PL-032)
+status: complete
+---
+
+## Summary
+
+Ships the read-only "My Picks" tab (BUSINESS_SPEC §6, §10, §12.4-12.5) plus in-range prev/next phase navigation. The view resolves the league's current phase, displays each event's teams, scores, odds (ATS only), and the user's existing picks, and surfaces phase-wide / per-event lock state. Interactive submission is intentionally deferred to PL-028.
+
+Also introduces the `picks` schema (migration 0009) with all fields every epic story needs (`leagueId`, `userId`, `phaseId`, `eventId`, `teamId`, nullable `spreadAtLock`, nullable `pickResult`), and the two new time-gate helpers (`selectLeagueCurrentPhase`, `isPhaseLocked`, `isPickLocked`) used across the epic.
+
+## Business Spec Coverage
+
+- §6.1 — phase label + order (rendered via `phaseLabel` / `comparePhasesByOrdinal`).
+- §6.3 — current-phase resolution: active → nearest upcoming → most-recent; scoped to the league's range.
+- §6.4 — prev/next navigation; browsing historical phases preserves the search-param phase.
+- §6.5 — Pro Bowl / pre-season phases excluded by the sync pipeline; the view never has to filter them.
+- §7.3 — My Picks tab always shows only the user's own picks (data helper filters by `userId`).
+- §10.1-10.3 — event status rendering (not_started / in_progress / final) with score + result badge.
+- §12.4 — My Picks tab layout: header (rank/record/points) + phase nav + lock banner + event cards.
+- §12.5 — read-only portions only (lock banner + per-game lock + results + ATS spread display). Interactive selection is PL-028.
+
+## Decisions
+
+- **Picks schema landed in this story** rather than PL-028. Reading an empty picks list for the view is cleaner than a placeholder cast, and one migration up-front beats a second migration when PL-028 flips columns from "absent" to "nullable". All epic-level fields (`spreadAtLock`, `pickResult`) are nullable from day one so PL-028 / PL-015 don't need schema churn.
+- **`pickResult` cached on the row.** §8.5 lets admin overrides clear it; PL-015 recalcs re-derive it. The view already reads it and renders win/loss/push badges in the expected colors (emerald / destructive / amber).
+- **`(leagueId, userId, eventId)` unique constraint.** A user picks once per event per league; the same user can pick the same event differently in two leagues. FK to `teams` uses `onDelete: restrict` — team deletions shouldn't silently drop pick history.
+- **Per-event odds: deterministic dedupe by sportsbook name.** The `odds` table is keyed `(eventId, sportsbookId)`, so a naive `Map(o => [o.eventId, o])` drops rows non-deterministically. The new `getOddsForEventsWithSportsbook` joins the sportsbook name and `ORDER BY name ASC`; the page keeps the first row per event. ESPN Bet is currently the only seeded sportsbook, so the outcome is ESPN Bet today; if a second sportsbook ever lands, this is the place to decide priority. Sportsbook name is surfaced as "Odds by …" attribution on the card (§9.2).
+- **`isPhaseLocked` split out of `isPickLocked`.** The banner needs the phase-wide gate; per-game lock delegates to it. Keeps the single source of truth for "what does locked mean?" in `lib/nfl/leagues.ts`, not inline in the page.
+- **Time formatting uses `date-fns-tz` → `America/New_York`** for both the pick-lock banner and event kickoff times. The spec defines pick locks in ET and NFL games are ET-scheduled, so fixing the displayed TZ makes the label match what the commissioner configured (and matches the `Intl.DateTimeFormat(undefined)` server-side TZ trap the admin overrides page already avoids).
+- **Phase navigation scoped to the league's range.** Prev/next buttons only cross phases that satisfy `isPhaseInLeagueRange(phase, league)`. A postseason-only league's My Picks never shows regular-season phases, even when a regular-season phase is currently active.
+- **Requested-phase fallback.** `?phase=<id>` is honored only when the phase exists in the league's range; otherwise we fall back to `selectLeagueCurrentPhase`. This prevents a stale bookmark from the prior season from rendering a 404 or out-of-range phase.
+- **Lazy standings header.** When the standings row doesn't yet exist for the current season (a legitimate state before the lazy creation in PL-015 runs), the header shows 0/0/0/0 with rank=1 — a correct dense-rank default when nothing has been scored.
+
+## Deviations from the Story
+
+- **Absorbs PL-032 per the epic plan.** Phase nav + historical browsing ship in this story instead of a follow-up. PL-032 row in `work/Backlog.md` is closed with a pointer to this commit.
+
+## Notable / Gotchas
+
+- **§10.3 `period` and `clock` live fields are not rendered.** The `events` schema doesn't persist them and the live-scores sync throws away the ESPN fields. Pre-existing gap, not introduced here; the "LIVE" chip and running scores still render. Flag as follow-up (see below).
+- **`sportsbookName` attribution renders only for ATS leagues.** Straight-up leagues don't consume odds so surfacing a provider would be misleading; the card hides the "Odds by …" line.
+- **`selectLeagueCurrentPhase` treats `endDate` as exclusive** (`now >= startDate && now < endDate`). BUSINESS_SPEC §6.3 says "between its start and end date" which is ambiguous — with the fixture convention that consecutive phases abut at the same instant (`week N.endDate == week N+1.startDate`), exclusive end is the only non-overlapping reading. Flagged in spec trace; leave as-is.
+- **Admin-override pickResult invalidation is not wired yet.** PL-015 owns that path (clear `pickResult` + scoped recalc inside `updateEventAction`).
+- **Page refetches season / phases that the layout also fetches.** The parent `(app)/leagues/[leagueId]/layout.tsx` already loads `seasons → currentSeason → phases` to render the season-state badge. The Drizzle client doesn't dedupe, so we pay it twice. Small enough for now; consider a route-level data loader when PL-031 also joins this pattern.
+
+## Follow-ups
+
+- **Live `period` / `clock` display (§10.3).** Add `period` + `clock` text to the `events` schema, update the sync pipeline to persist them, and render them on live cards. Or soften §10.3 if product decides LIVE + scores is enough. Flagged by spec-tracer.
+- **Sportsbook priority when a second book is seeded.** Today the alphabetic "first per event" fallback works because ESPN Bet is the only book. When a second one lands, add a `primary` flag or an explicit preference argument to `getOddsForEventsWithSportsbook`.
+- **Header + layout data dedupe.** If PL-031's standings tab also re-fetches `seasons`/`phases`, consider hoisting these into a shared server-only helper per `[leagueId]` route segment.
+- **Interactive UI (PL-028)** swaps the read-only team rows for clickable selections, adds the sticky "Submit Picks (n/m)" progress button, and uses `isPickLocked` to disable individual games as they kick off.
+
+## Code-reviewer findings
+
+Three blockers fixed before commit:
+1. Non-deterministic odds dedupe + missing sportsbook attribution → replaced `getOddsForEvents` with `getOddsForEventsWithSportsbook`, deterministic `Map.set-if-absent` dedupe, attribution rendered on ATS cards.
+2. `Intl.DateTimeFormat(undefined, …)` for server-rendered dates (TZ mismatch / hydration risk) → swapped to `formatInTimeZone` with `America/New_York` on both the banner and the event card.
+3. Raw `now >= phase.pickLockTime` in the page (business logic in a page) → extracted `isPhaseLocked(phase, now)` helper in `lib/nfl/leagues.ts`, with tests; page delegates.
+
+Non-blockers surfaced:
+- `getPicksForLeaguePhase` `orderBy(createdAt)` is inert for the current Map-based consumer (kept in case PL-028/PL-033 want a submission timeline).
+- Page re-fetches season/phases the layout already loaded (see Gotchas).
+- `asChild`+`disabled` on the phase-nav Button mixes two Radix modes; the pointer-events-none fallback keeps it correct but a cleaner pattern would split disabled/enabled branches. Deferred.
+
+## Spec-tracer findings
+
+No blocker divergences. One surfaced non-blocker: §10.3 period/clock fields unimplemented (pre-existing schema gap; see Follow-ups). §6.3 end-exclusive boundary flagged as ambiguous-spec rather than a code bug.

--- a/work/tasks/PL-028.md
+++ b/work/tasks/PL-028.md
@@ -1,0 +1,85 @@
+---
+id: PL-028
+title: Pick submission — straight up + ATS (absorbs PL-029)
+status: complete
+---
+
+## Summary
+
+Turns the PL-027 read-only "My Picks" tab into an interactive submission surface when the phase is unlocked. One `submitPicksAction` handles both straight-up and against-the-spread leagues: same validation pipeline, same delete-then-insert pattern, `pickType`-branched spread freezing. PL-029 is absorbed here (the ATS case is a conditional inside the same code path, not a separate action/form).
+
+Submission is all-or-nothing, exactly `min(league.picksPerPhase, unstartedEvents)` picks per submission. Already-started games in the phase keep their prior picks untouched; the delete is scoped to `unstartedEventIds` only. ATS leagues freeze the live spread for the picked side into `spreadAtLock` on every submission, matching §9.3.
+
+## Business Spec Coverage
+
+- §7.1 #1 — `assertLeagueMember(session.user.id, leagueId)` throws ForbiddenError for non-members.
+- §7.1 #2 — `phase` must belong to the league's current season AND be inside the league's range. Past phases fail the `isPhaseLocked` gate; future-but-unlocked phases are allowed (see Gotchas).
+- §7.1 #3 — `isPhaseLocked(phase, now)` from `lib/nfl/leagues.ts`; `now = getAppNow()`.
+- §7.1 #4 — exactly `min(picksPerPhase, unstartedEvents.length)` picks per submission, exact-count enforced.
+- §7.1 #5 — in-submission duplicate game rejection via `Set<eventId>` scan.
+- §7.1 #6 — each picked game must be in this phase and `now < event.startTime`.
+- §7.1 #7 — `event.homeTeamId === sel.teamId || event.awayTeamId === sel.teamId`.
+- §7.1 #8 / §9.3 — ATS branch fetches `getOddsForEventsWithSportsbook`, derives `spreadAtLock` from the picked side, errors out if the spread isn't synced yet.
+- §7.2 — re-submitting deletes only `unstartedEventIds` picks and inserts the new set atomically; picks on started games in the same phase survive. Spread snapshot re-derived from fresh odds on every submission.
+- §7.3 — `getPicksForLeaguePhase(leagueId, userId, phaseId)` always filters by `userId`. My Picks view never loads other members' picks.
+- §12.5 — interactive UI: toggle selection, sticky submit button showing progress `(picksMade/requiredCount)`, disabled when count mismatches, can't select more than required.
+
+## Decisions
+
+- **Single action for both pick types.** PL-029 absorbed: the ATS branch is an inline conditional on `league.pickType === "against_the_spread"` in the same action. Adds ~30 lines for freezing `spreadAtLock` per picked team and validating odds presence. Separate stories would have duplicated the entire validation pipeline.
+- **Delete-then-insert over upsert.** A submission is the complete replacement set for unstarted games in the phase (§7.1 #4 "submit exactly N"). If the user previously picked events A/B/C and re-submits with B/C/D, A's pick must be removed. Upsert would have left A's orphaned row behind. `deleteUserPicksForEvents(leagueId, userId, unstartedEventIds)` scopes narrowly enough to preserve started-game picks (§7.2), and the transaction ensures we never see a "picks partially deleted, not yet inserted" state.
+- **Batch insert via `insertPicks(rows[])`.** Reviewer flagged the initial `for … await insertPick` as an N+1 (up to 16 round trips). Single `client.insert(picks).values(rows)` is one statement.
+- **`insertPick` helper removed.** Batch-only surface; callers that want to add one pick pass a 1-length array. Keeps the data layer's write API narrow.
+- **Current-season seasonId guard.** `getPhaseById` is keyed by UUID, so a caller could pass a phaseId from a prior year whose `(seasonType, weekNumber)` tuple still matches the league's range and whose `pickLockTime` is in the future (e.g. 2099 Week 3 submitted against a league whose current season is 2026). The action now loads `selectCurrentSeason(...)` and rejects when `phase.seasonId !== currentSeason.id`.
+- **Spread-only odds selection is deterministic.** Same sportsbook dedupe used by PL-027 (sort by name, take first per event) — `oddsByEventId` Map only holds one row per event. Side-picked spread (home vs. away) is extracted via `sel.teamId === event.homeTeamId ? odds.homeSpread : odds.awaySpread`.
+- **Spread null check treats "no line yet" as a business error.** If odds haven't synced for one of the picked games (row missing or `homeSpread`/`awaySpread` null), the action returns a recoverable error ("Spreads aren't available yet for one of the games. Try again in a moment.") rather than silently storing `null`. The user can retry once the odds sync catches up.
+- **Form seeds selections from existing unstarted picks.** On first render, the client computes the initial Map from the user's current picks on unstarted events, so the form shows their prior choices highlighted. Toggling a row un-selects it.
+- **"Can't select more than required" enforced in the form via toast.** Clicking an unpicked row when `selections.size === requiredCount` shows a toast ("deselect one first") instead of silently failing the submit.
+- **`event-pick-card.tsx` refactored to be `"use client"`.** The form needs interactive callbacks; the same component renders both the read-only PL-027 case and the interactive PL-028 case. Keeping a single card avoids divergence between "my-picks read-only" and "my-picks interactive". Props changed: instead of a whole `pick: UserPick | null`, the card takes `selectedTeamId`, `frozenSpread`, `pickResult` explicitly — this lets the form pass virtual selection state cleanly without constructing a fake Pick object.
+- **Page branches on `phaseLocked`.** Server component renders `<SubmitPicksForm>` when the phase is unlocked and the read-only event list when locked. Both paths share the same header / navigation / banner.
+- **`nowMs` prop passed into the form.** The server resolves `getAppNow()` once and hands the timestamp to the client form so selection logic doesn't redo "is this unlocked?" against a wall-clock `new Date()`. The server re-validates on submit.
+
+## Deviations from the Story
+
+- **Absorbs PL-029 per the epic plan.** No separate ATS-submission story; ATS code path lives inside `submitPicksAction`. PL-029 row in `work/Backlog.md` closed with a pointer to this commit.
+
+## Notable / Gotchas
+
+- **"Current phase only" (§7.1 #2) is not strictly enforced.** Submissions to a future-but-unlocked phase in the current season succeed. Spec-tracer flagged this; I left it as a non-blocker because (a) NFL phase lock times sit inside each week's window so the practical window for "can submit next week's picks" is small, (b) per-event `not-started` gate still protects against picks on already-started games, and (c) the UI only routes users to the current phase by default. A strict enforcement would require piping `selectLeagueCurrentPhase(...)` into the action and matching `phase.id === currentPhase.id`. Consider tightening if product decides early-submit is undesirable.
+- **Zod schema `max` uses the global `PICKS_PER_PHASE_MAX = 16`, not per-league.** The per-league exact count is enforced in the action; the Zod bound is defense-in-depth against pathological payloads.
+- **Interactive event card is now a client component.** The read-only PL-027 branch previously enjoyed pure server rendering; now it pulls in a small client bundle for what used to be SSR-only. Acceptable because the card is a leaf and the page + layout around it stay server-rendered.
+- **Client `nowMs` can drift across a page session.** If a user leaves the form open past a game's kickoff, the form still lets them toggle a row for a started game — the server rejects it on submit. Not a correctness issue; could be a UX polish item (e.g. refresh on route focus).
+- **`revalidatePath` hits `league-picks` too.** That route's UI lands in PL-033. Calling `revalidatePath` on a not-yet-implemented route is a no-op today; when PL-033 ships, visibility unlocks correctly post-submit.
+
+## Follow-ups
+
+- **Tighten "current phase only" (§7.1 #2).** Optional; wait for product input on whether early-submission to an unlocked next-week phase is a feature or a bug.
+- **Refresh-on-kickoff UX.** When the browser tab is foregrounded, re-fetch to update the form's `nowMs` so newly-started games lock in the UI.
+- **Split `EventPickCardReadOnly` (server) from `EventPickCardInteractive` (client).** If the read-only PL-027 / PL-033 surface becomes perf-sensitive. Currently both render from the same `"use client"` component.
+
+## Code-reviewer findings
+
+Two blockers fixed before commit:
+
+1. Wrong-season phaseId accepted → added `selectCurrentSeason` + `phase.seasonId === currentSeason.id` check with a new test.
+2. N+1 inserts in a for loop → added `insertPicks(rows[])` batch helper; action builds the rows once and calls it once. Tests updated to assert a single batched call.
+
+Non-blockers surfaced in decisions / notes:
+
+- Duplicated spread-lookup in validate vs. persist paths → folded into `frozenSpreadByEventId` Map.
+- "No games left" copy slightly off for empty phases → kept; not user-reachable today.
+- Revalidation path list will grow with future stories → noted.
+- Client `nowMs` staleness → noted.
+- Client-component boundary pushed up → accepted trade-off.
+
+## Spec-tracer findings
+
+No blocker divergences. Non-blockers:
+
+- §7.1 #2 "current phase only" is weaker than the spec literal reads (see Gotchas). Left as-is; reconsider with product input.
+- Zod `max` bound is the global cap, not per-league. Action enforces the real rule.
+
+Two missing-coverage tests added:
+
+- §7.2 — started-event picks survive re-submit (delete scope excludes started event ids).
+- §9.3 — second submission refreshes `spreadAtLock` to the current line when odds moved.

--- a/work/tasks/PL-030.md
+++ b/work/tasks/PL-030.md
@@ -1,0 +1,61 @@
+---
+id: PL-030
+title: Pick results calculation
+status: complete
+---
+
+## Summary
+
+Pure scoring module — `lib/nfl/scoring.ts` — with three exported functions used downstream by PL-015 (standings recalc) and PL-031 (standings UI):
+
+- `calculatePickResult(pick, event, pickType)` → `"win" | "loss" | "push" | null` (null = unscoreable)
+- `calculateStandingsPoints(results)` → `{ wins, losses, pushes, points }`
+- `denseRank(entries, getPoints)` → `{ entry, rank }[]` with BUSINESS_SPEC §8.4 tie semantics
+
+22 tests cover every §8.1 branch (SU win/loss/push, ATS at every boundary, pick'em, unscoreable states), §8.2 points math, and §8.4 rank examples.
+
+## Business Spec Coverage
+
+- §8.1 — straight-up scoring (`pickedScore` vs `opponentScore`) and ATS scoring (`pickedScore + spreadAtLock` vs `opponentScore`). Both branches handle win/loss/push deterministically.
+- §8.2 — `points = wins × 1 + pushes × 0.5`, losses contribute 0.
+- §8.4 — rank assignment with ties shared and `nextDistinctRank = previousRank + tiedCount` (matches the spec's worked example "tied at 1 → next is 3").
+- §10.2 — a pick is scoreable only when `event.status === "final"` and both scores are present (authoritative scoring source).
+- §14 — constants `POINTS_PER_WIN = 1`, `POINTS_PER_PUSH = 0.5`, `POINTS_PER_LOSS = 0` match the spec.
+
+## Decisions
+
+- **Pure module, no side effects, no `data/` imports.** Scoring is `(pick, event, pickType) → PickResult`. PL-015 owns the orchestration that reads events + picks, calls this, and writes the results.
+- **`null` for unscoreable states.** Rather than throw, `calculatePickResult` returns `null` when the event isn't final, scores are missing, the picked team isn't a participant, or an ATS pick has no frozen spread. Callers (PL-015) treat `null` as "skip, stays unscored" — this is the invariant PL-015's integrity pass relies on.
+- **Types narrowed via `Pick<Event, …>`** rather than taking a full `Event`. Keeps the function signature honest about what it actually reads (`status`, `homeTeamId`, `awayTeamId`, `homeScore`, `awayScore`).
+- **`calculateStandingsPoints` takes `readonly (PickResult | null)[]`.** Immutable input — the function just counts. Null entries are ignored, matching §8.5's "score only picks whose games have final scores".
+- **`denseRank` does not mutate its input.** `[...entries].sort(...)` copies first. The function is generic on `T` so PL-031 can rank standings rows, members, or anything else with a `points` projection.
+- **Constants exported.** PL-015 imports `POINTS_PER_WIN` / `POINTS_PER_PUSH` directly so the "what points does a win score?" invariant has a single source of truth.
+
+## Deviations from the Story
+
+- None. Pure logic, no cross-story effects.
+
+## Notable / Gotchas
+
+- **§8.4 spec calls it "dense ranking" but the formula + example describe competition/standard ranking** (1,1,3,3,5 — not 1,1,2,2,3). Spec-tracer flagged this. My implementation follows the spec's **formula and example** (so behavior is correct against the spec as written). The function name `denseRank` and the comment referencing `§8.4 — dense ranking` are the only places that echo the spec's naming; if we decide to rename the spec to "competition ranking", the code gets a trivial rename. See Follow-ups.
+- **ATS pick with `spreadAtLock = null` returns `null` (unscoreable), not an error.** PL-028's submission action already blocks ATS picks without a spread, so this case shouldn't occur in practice — but the defensive null keeps PL-015 from faulting on stale rows.
+- **SU picks may carry a non-null `spreadAtLock`** (theoretically, if a league flipped pick types after submission — not a current feature). Scoring ignores the spread for SU picks, so this is harmless.
+- **Ranking is points-only.** No tiebreaker beyond points — this matches §8.4's "tied members share the same rank". If product ever wants secondary tiebreakers (e.g. total wins), they'd be new spec work.
+
+## Follow-ups
+
+- **Rename §8.4 to "competition ranking"** (or change the worked example + formula + implementation to true dense ranking). Behavior and spec example currently agree; only the name mismatches. Raise with product — no PR change needed until a direction is chosen. Non-blocking per spec-tracer.
+- **PL-015 will consume these three functions** and invalidate cached `pickResult`s on admin event edits. This story doesn't wire any call sites — that's PL-015's scope.
+
+## Code-reviewer findings
+
+No blockers. Four non-blockers — three addressed before commit:
+
+1. Explicit return type on `calculateStandingsPoints` input widened to `readonly` (non-blocker 1 — styled for immutability).
+2. Dropped the `!` non-null assertion in the test fixture in favor of `=== undefined` narrowing (non-blocker 2).
+3. Added the multi-tie-group `denseRank` test (non-blocker 4) — `[5,5,3,3,1] → [1,1,3,3,5]`.
+4. Non-blocker 3 (cross-case test SU-with-non-null-spread) noted as implicit; not added.
+
+## Spec-tracer findings
+
+Zero divergences from the cited sections. One terminology concern surfaced (see Gotchas): spec §8.4 labels the ranking method "dense ranking" but the worked example is competition/standard ranking; implementation faithfully follows the spec's formula and example, so the code is correct. Flagged as follow-up only.

--- a/work/tasks/PL-031.md
+++ b/work/tasks/PL-031.md
@@ -1,0 +1,64 @@
+---
+id: PL-031
+title: Standings + leaderboard UI
+status: complete
+---
+
+## Summary
+
+Replaces the Standings tab stub with a real leaderboard that reads `league_standings` for the selected season. Includes a season switcher (dropdown) when the league has standings for multiple years so users can browse prior seasons per §3.5. Viewer's row is highlighted and shows "(you)" next to their name.
+
+## Business Spec Coverage
+
+- §8.3 — rank, player identity (avatar + name + @username), points, W-L-P rendered as columns.
+- §8.4 — dense-rank values are populated by PL-015 and persisted; this UI just renders `rank` as the first column.
+- §3.5 — seasons with standings are loaded via `getSeasonsWithStandingsForLeague`; a `?season=<seasonId>` search param navigates between them.
+- §12.4 — Standings tab layout: header with optional season switcher + leaderboard table.
+
+## Decisions
+
+- **Season resolution extracted to `lib/nfl/leagues.ts#selectStandingsSeason`.** The page can't host business logic, so the "which season do we show?" decision (honor `?season` → current season if it has standings → most recent historical → current season as fallback) lives in a pure helper with 5 tests.
+- **Dropdown draws from the historical list.** `getSeasonsWithStandingsForLeague` returns only seasons where this league already has a standings row. The current season is appended if it's missing so brand-new leagues still show a year label in the dropdown even before the first recalc runs.
+- **Newest-first ordering.** Every other "season list" surface in the app (season-state-badge, etc.) reads newest-first; matched here.
+- **Rank-ordered, username-tiebroken read.** `getStandingsForLeagueSeasonWithProfiles` does `orderBy(asc(rank), asc(username))` so ties (§8.4 dense ranking) fall in a deterministic alphabetical order.
+- **Viewer-row highlight is additive to the spec.** §12.4 doesn't require it, but "(you)" + subtle `bg-primary/5` row styling is a small UX win consistent with how the Members tab calls out the viewer.
+- **`formatPoints` lifted into `lib/nfl/scoring.ts`.** Was duplicated in MyPicksHeader and StandingsTable with the same integer-vs-decimal-.5 branch. Centralized next to the §8.2 points math so both consumers import from the same source.
+- **No per-column interactive sorting.** §12.4's "sortable leaderboard" is naturally satisfied by rank ordering — there's no other meaningful sort (sorting by wins or pushes would misrepresent the league standings). If product decides they want clickable column headers, add later.
+- **Switcher suppressed when only one season is selectable.** Keeps the header clean for first-season leagues.
+
+## Deviations from the Story
+
+- None.
+
+## Notable / Gotchas
+
+- **§12.4 "sortable leaderboard" wording is ambiguous.** Spec-tracer flagged it; implementation renders a rank-ordered table with no interactive column sorting. Product can confirm whether that satisfies the spec.
+- **Anonymous users**: `getStandingsForLeagueSeasonWithProfiles` does an INNER JOIN on `profile.userId = leagueStandings.userId`. If a user is fully deleted (not just soft-anonymized per §2.3), their standings row drops off the leaderboard. §2.3 uses soft anonymization which preserves the profile row, so this is fine — but worth noting that hard-deleted users would disappear.
+- **`formatPoints` is uncovered by direct tests.** It's a thin formatter branch (integer vs `.toFixed(1)`); exercised indirectly via consumer components. Non-blocker per `rules/testing.md`.
+- **Empty state only fires when `selectStandingsSeason` returns null.** Given `selectCurrentSeason` has a most-recent-season fallback, that state is reachable only when there are zero seasons in the DB (e.g. NFL setup hasn't run) — probably unreachable in practice, kept as a defensive fallback.
+
+## Follow-ups
+
+- **Interactive column sorting (§12.4)** if product decides "sortable" really means user-reorderable.
+- **Rendering anonymized users with a clear label** (`Anonymous User` + blank avatar) instead of silently dropping them via INNER JOIN would be more honest once deleted users show up on historical leaderboards.
+- **Empty-season UX**: when standings exist for 2024 but 2025 is empty (pre-recalc), the table currently renders the empty state. Once PL-015 runs, the lazy zero-init rows fill in. Depending on when the cron fires, there may be a brief window where a new season looks "dead" — worth a follow-up if users flag it.
+
+## Code-reviewer findings
+
+One blocker, fixed before commit:
+
+1. Season-selection business logic in the page → extracted to `lib/nfl/leagues.ts#selectStandingsSeason` with 5 tests covering every branch.
+
+Non-blockers addressed:
+
+- Duplicated `formatPoints` → lifted to `lib/nfl/scoring.ts`.
+- Dropdown sort ascending → flipped to descending (newest first).
+
+Non-blockers deferred:
+
+- `URLSearchParams` constructor pattern differs slightly from the existing admin filter — harmless, left as-is.
+- Dropdown label reads "2024" vs the admin filter's "2024 season" — layout already shows the state badge above, so the bare year is unambiguous.
+
+## Spec-tracer findings
+
+Zero blocker divergences. One non-blocker: "sortable leaderboard" wording in §12.4 — implementation delivers rank-ordered with deterministic tiebreak, no interactive column sorting. Logged in Follow-ups.

--- a/work/tasks/PL-033.md
+++ b/work/tasks/PL-033.md
@@ -1,0 +1,58 @@
+---
+id: PL-033
+title: League picks view
+status: complete
+---
+
+## Summary
+
+Replaces the League Picks tab stub with a phase-aware member-by-member view. Before the phase locks (§7.3), the tab shows a "visible after the deadline" message; after the lock, it renders a collapsible card per member (ordered by standings rank) with that member's picks for the phase, plus their seasonal record and points.
+
+## Business Spec Coverage
+
+- §7.3 — before the phase's pick lock, only the "coming soon" message is rendered. The page doesn't even fetch picks in that branch. After the lock, every member's picks for the phase are visible.
+- §12.4 — League Picks tab layout: member cards that collapse/expand, showing picks, record, and points.
+- §6.4 — phase navigation (prev/next) mirrors the My Picks tab so users can browse past phases — locked phases always render, current/future phases wait for their lock.
+
+## Decisions
+
+- **Visibility gate is a branch on `isPhaseLocked`.** Reuses the single source of truth from `lib/nfl/leagues.ts` (already tested) — same gate that drives My Picks' read-only display and the server-side submission rejection.
+- **Data fetch is nested in `LockedPhaseContent`.** The page renders `EmptyState` and returns early when the phase is unlocked, so the pre-lock path never queries picks. Only after the lock does the async `LockedPhaseContent` component kick off the three fetches (`getEventsByPhaseWithTeams`, `getPicksForLeaguePhaseAllMembers`, `getStandingsForLeagueSeasonWithProfiles`, `getOddsForEventsWithSportsbook`) in parallel.
+- **Standings row drives membership list + ordering.** `getStandingsForLeagueSeasonWithProfiles` already orders by `rank ASC, username ASC`, so ranking ordering falls out for free. Former members with historical standings stay in the list (consistent with §4.3 via PL-015's behavior).
+- **Default-open viewer's own card.** Small UX win — the viewer's card starts expanded so they can see their own picks immediately. Other members collapse by default to reduce noise on mobile.
+- **Native `<details>` / `<summary>` for collapsible.** No JS needed, keyboard-accessible by default, survives hydration without extra client bundle. Styled with Tailwind; the default disclosure triangle is hidden and a rotating chevron is rendered instead.
+- **Reuses `EventPickCard`.** Same display component as My Picks, always in `isLocked={true}` mode since we're showing a locked phase. Pick-result badges, frozen spreads, and scores all render consistently across My Picks / League Picks.
+- **Phase-resolution block duplicated with My Picks.** Intentional short-term duplication — see Follow-ups. Extraction is safer once the epic's end-of-epic review can see both call sites side by side.
+
+## Deviations from the Story
+
+- None. Scope matches backlog.
+
+## Notable / Gotchas
+
+- **Future phases show the "coming soon" message.** A user can navigate to a future phase via `?phase=<id>` and the view correctly refuses to show picks until that phase locks. Consistent with §7.3 and what a user might intuitively expect when browsing ahead.
+- **Historical phases always show picks.** Any phase past its pickLockTime is "locked" regardless of how many games have happened in it; members' picks for past phases are visible.
+- **Members without a standings row won't render on this page.** Standings are inserted at join time (`lib/invites.ts`) and upserted during recalc (PL-015), so this shouldn't happen in practice. A silent gap — worth noting in case a future data-layer refactor breaks the join-time insert.
+- **`LockedPhaseContent` calls `getSession()` itself** rather than receiving `viewerUserId` from the parent. Both patterns are fine in Next.js 16 server components; local call keeps the session cost out of the pre-lock path.
+- **`MemberPicksCard` reuses `EventPickCard` in locked mode.** Score/spread/result rendering stays identical to My Picks. No new visual language to learn across tabs.
+
+## Follow-ups
+
+- **Extract a shared phase-resolution helper.** `my-picks/page.tsx` and `league-picks/page.tsx` each have a ~45-line block that resolves league/season/phases/selected/prev/next from the request. Flagged by code-reviewer. A `resolveSelectedPhase` helper in `lib/nfl/leagues.ts` would dedupe — I'm leaving it for the end-of-epic validation pass so the refactor touches both call sites at once.
+- **Silent drop of members without standings.** Revisit when season-rollover edge cases surface in manual testing — if a brand-new member joins mid-phase and somehow misses the join-time standings insert, they'd disappear from this view.
+
+## Code-reviewer findings
+
+No blockers. Three non-blockers addressed before commit:
+
+- Inline `PickType` union in `LockedPhaseContent`'s props → replaced with `Pick<League, "pickType">`.
+- `getPicksForLeaguePhaseAllMembers` missing `ORDER BY` → added `asc(userId), asc(createdAt)` for deterministic reads.
+- `getSession()` called before early returns → moved into `LockedPhaseContent` so the pre-lock path doesn't pay for it.
+
+Deferred to epic validation:
+
+- Phase-resolution duplication between my-picks and league-picks — will tackle with a shared helper once both call sites can be refactored together.
+
+## Spec-tracer findings
+
+Zero divergences from the cited sections. Noted the default-open viewer card + rank ordering as additive UX not required by §12.4.


### PR DESCRIPTION
## Summary

End-to-end Picks & Scoring for the PicksLeagues MVP. Adds the `picks`
schema + pick submission + per-game/per-phase lock enforcement + scoring
(straight-up and against-the-spread) + an integrity-checked standings
recalc that wires into live-scores cron, the simulator's `advancePhase`,
and the admin event-override flow. UI: My Picks (read-only + interactive
branches), League Picks (before-lock gate + after-lock member cards),
and the Standings tab (leaderboard with historical season switcher).

## Stories shipped

- PL-027 — Phase picks view (absorbs PL-032) — `210d336`
- PL-028 — Pick submission, SU + ATS (absorbs PL-029) — `1dda849`
- PL-030 — Pick results + standings points + dense rank — `2529763`
- PL-015 — Standings recalculation service — `1a10bf3`
- PL-031 — Standings + leaderboard UI — `ae9cd93`
- PL-033 — League picks view — `da312d1`
- chore: end-of-epic cleanup (helper extractions, record format) — `0353568`

## BUSINESS_SPEC coverage

- §6.1 / §6.3 / §6.4 — phase labels, current-phase resolution, prev/next nav
- §7.1 / §7.2 — submission rules + per-game / per-phase lock + locked-pick preservation on re-submit
- §7.3 — visibility gate (self-only before lock, everyone after)
- §8.1 / §8.2 — pick-result calculation (SU + ATS) and points math
- §8.3 / §8.4 / §8.5 / §8.6 — standings fields, dense ranking, recalc pipeline, lazy zero-init
- §9.3 — frozen ATS spread at submission time
- §10.1 / §10.2 / §10.3 — event status display (scheduled / live / final) with pick-result badges
- §12.4 / §12.5 — My Picks, League Picks, Standings tab layouts

## Manual test plan

> Stand up the simulator in one tab, log in as two users (use the admin
> simulator and two browser profiles if needed), and walk through the
> flows. Locations shown in `path · description` form.

**Golden path — straight-up submission → scoring**
- [x] Start simulator at a year with ESPN data; create a straight-up league via `/leagues/create`.
- [x] Invite + log in as a second user; both users visit `/leagues/<id>/my-picks`.
- [x] Before the phase's pick lock: submit 5 picks (Submit Picks (5/5) sticky button). Confirm toast + persisted selection on reload.
- [x] Advance simulator past the pick lock. My Picks should flip to read-only; League Picks should now show both members' picks in collapsible cards.
- [x] Advance simulator through the phase's games. Standings tab should update (you'll see your rank + record + points).

**Golden path — ATS**
- [x] Create an against-the-spread league with 2-pick limit. Submit picks — confirm spread displayed and sportsbook attribution ("Odds by ESPN Bet").
- [x] Before lock, re-submit with different selections. Confirm `spreadAtLock` refreshes (check DB if desired).
- [x] Before lock, re-submit a pick whose spread has changed (use admin overrides to bump an odds row). Confirm the new submission freezes the new spread.

**Locked-pick preservation (§7.2)**
- [x] Make picks on 3 games in a phase with 5 available. Use admin overrides or simulator to move one game's start time into the past.
- [x] Re-open My Picks and re-submit; only the 4 unstarted games should be selectable. The started game's pick should survive the re-submit.

**Admin override flow (§8.5)**
- [x] With a scored phase, go to `/admin/overrides` and flip a final game's winner (swap home/away scores).
- [x] Standings for every league that picked that game should update immediately — both rank and points.
- [x] Revert the edit; standings return to the prior state.

**Phase navigation (§6.4)**
- [x] Use the prev/next buttons on My Picks and League Picks. You should only see phases in this league's configured range.
- [x] Navigate to a past (locked) phase: League Picks should show members' picks. Navigate to a future unlocked phase: League Picks should show the "visible after deadline" message.

**Standings tab**
- [x] Single-season league: no season dropdown, just the leaderboard.
- [ ] Multi-season league (use simulator to roll across years): season dropdown appears and switches between leaderboards via `?season=`.
- [x] Viewer's row is highlighted and labeled "(you)".

**Regression checks (adjacent flows)**
- [x] Non-member visiting any `/leagues/<id>/*` URL gets a 404 (layout-level `getLeagueMember` gate).
- [x] Creating a league still works end-to-end; the new member is initialized with a zero-standings row.
- [x] Join invite flow still succeeds and gets a zero standing.
- [x] Leaving a league still removes the user's standings rows.
- [x] Admin override's "no-op" failure path (NotFoundError on a non-existent event) does NOT clear any pick results or trigger a recalc — verified by unit test, worth a spot-check in dev.

## Known limitations / follow-ups

- **§8.4 ranking terminology.** The spec calls it "dense ranking" but the
  worked example (`1,1,3,3,5`) is competition/standard ranking. Code
  matches the spec's example (behavior correct, name mismatches).
  Decide spec name vs code name; no behavior change needed.
- **§10.3 period/clock** for live games is unimplemented — the schema
  doesn't persist those fields. "LIVE" chip + running score still
  render; period/clock are empty.
- **§7.1 #2 "current phase only"** is enforced loosely: submission accepts
  any unlocked in-range phase in the current season, not just the
  current phase. Per-event `not-started` gate still protects the
  payload. Tighten if product wants strict "current phase only".
- **Live-scores recalc is broader than BACKGROUND_JOBS §5 literally reads**
  — implementation does the full `runStandingsRecalc()` sweep rather
  than scoping to leagues with picks on the just-finalized events. The
  result is a strict superset; flag for optimization if it shows up in
  profiles.
- **Submit form doesn't use react-hook-form.** Selection-list UX didn't
  fit the RHF field model; an explicit carve-out in UI rules would
  stop the next pick-submission form from re-litigating.
- **Sportsbook priority** — `indexPrimaryOddsByEvent` picks the
  alphabetically-first sportsbook per event. Works because ESPN Bet is
  the only seeded sportsbook today; add an explicit priority when a
  second lands.

## How to test locally

```bash
git checkout epic/picks-and-scoring
pnpm install
pnpm exec drizzle-kit migrate  # applies migration 0009_picks_table
pnpm dev
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)