### PR TITLE
docs(runbook): note Deployment Protection must be disabled for previews

### DIFF
--- a/docs/runbooks/environments.md
+++ b/docs/runbooks/environments.md
@@ -41,6 +41,10 @@ config anywhere — add it only if a real cross-origin consumer ever appears.
    **with the `createRequire` banner** so CJS deps like `pg` can `require` Node built-ins at
    runtime (omitting the banner builds fine and crashes prod at cold start), and writes the
    route table (hashed assets → static files → `/api/*` → function → SPA fallback).
+5. Settings → Deployment Protection → set **Vercel Authentication** to Disabled. Previews
+   only ever build the `staging` branch (the `ignoreCommand`), and staging must be publicly
+   reachable — left on, `staging.picksleagues.com` 302s every request to Vercel SSO and the
+   OAuth callback flows can't complete.
 
 ### Neon — one project, branch per environment
 


### PR DESCRIPTION
## Summary

Staging deploys are Ready but every request to staging.picksleagues.com 302s to Vercel SSO — Deployment Protection (Vercel Authentication) is on by default for Preview deployments. Documents the console step to disable it: previews only ever build `staging` (ignoreCommand), and staging must be publicly reachable or OAuth callbacks can't complete.

## Test plan

- [x] After toggling in console: `curl https://staging.picksleagues.com/api/health` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)