### PR TITLE
feat(ci): Migrate workflow for deployed databases (ADR-0003)

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -1,0 +1,64 @@
+# Applies drizzle migrations to the environment matching the pushed branch
+# (ADR-0003: PRs merge to staging → Neon staging; staging merges to main →
+# Neon primary; the promotion flow means staging always migrates before prod
+# reaches the same commit).
+#
+# Required repo secrets (docs/runbooks/environments.md §Migrations) — use the
+# DIRECT (non-pooler) Neon URLs; DDL doesn't mix with transaction pooling:
+#   STAGING_DATABASE_URL — Neon `staging` branch connection string
+#   PROD_DATABASE_URL    — Neon primary branch connection string
+#
+# Each branch maps to exactly one secret — no fallback, so main can never
+# migrate the staging database. Until the branch's secret exists the job
+# logs a notice and exits green before installing anything.
+name: Migrate
+
+on:
+  push:
+    branches: [staging, main]
+
+concurrency:
+  group: migrate-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    env:
+      STAGING_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+      PROD_DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+    steps:
+      - name: Resolve target database
+        id: guard
+        run: |
+          if [ "$GITHUB_REF_NAME" = "main" ]; then
+            url="$PROD_DATABASE_URL"
+          else
+            url="$STAGING_DATABASE_URL"
+          fi
+          if [ -z "$url" ]; then
+            echo "::notice::No database secret configured for $GITHUB_REF_NAME yet — skipping migrations."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "DATABASE_URL=$url" >> "$GITHUB_ENV"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - if: steps.guard.outputs.run == 'true'
+        uses: actions/checkout@v4
+
+      - if: steps.guard.outputs.run == 'true'
+        uses: pnpm/action-setup@v4
+
+      - if: steps.guard.outputs.run == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - if: steps.guard.outputs.run == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Apply migrations
+        if: steps.guard.outputs.run == 'true'
+        run: pnpm db:migrate

--- a/docs/adr/0003-migrations-via-github-actions.md
+++ b/docs/adr/0003-migrations-via-github-actions.md
@@ -1,0 +1,32 @@
+# 0003. Deployed-database migrations via GitHub Actions
+
+- **Status:** Accepted
+- **Date:** 2026-07-21
+- **Related:** architecture.md §Environments / D12, docs/runbooks/environments.md, backlog FND-9
+
+## Context
+
+Nothing applied Drizzle migrations to the Neon databases: CI migrates only its throwaway
+Postgres container, the Vercel build doesn't touch the DB, and the runbook never listed
+deployed migration as a provisioning step — so the first staging deploy served an empty
+schema (OAuth 500s on a missing `verifications` table). Options: migrate inside the Vercel
+build (needs an unpooled URL per scope; couples deploy to DB access), a GitHub Actions
+workflow on push to `staging`/`main` (paulitakes' proven design §7), or keep it manual
+(already demonstrated its failure mode).
+
+## Decision
+
+Mirror paulitakes: a dedicated `Migrate` workflow runs `pnpm db:migrate` on push to
+`staging` and `main`, selecting the **direct** (non-pooler) Neon URL from per-branch repo
+secrets — `STAGING_DATABASE_URL` / `PROD_DATABASE_URL`, no fallback between them, so `main`
+can never migrate the staging database. A missing secret logs a notice and exits green
+(incremental provisioning). Per-`ref` concurrency serializes runs.
+
+## Consequences
+
+Merges self-apply schema changes, and the promotion flow guarantees staging migrates before
+prod reaches the same commit. Neon URLs are duplicated into GitHub secrets (rotate in two
+places). The workflow races the Vercel deploy, so new code may briefly run against the old
+schema — migrations must stay backward-compatible for one deploy (expand/contract), which
+settlement's recompute-friendly design (D10) already encourages. Revisit if we ever need
+migrations gating the deploy itself (move into the Vercel build with an unpooled URL).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,3 +12,4 @@ Pre-baseline alternatives analysis lives in the architecture doc's own decision 
 | --------------------------------------------- | ------------------------------------ | -------- |
 | [0001](0001-record-architecture-decisions.md) | Record architecture decisions        | Accepted |
 | [0002](0002-baseline-architecture-v0-3.md)    | Adopt architecture v0.3 as baseline  | Accepted |
+| [0003](0003-migrations-via-github-actions.md) | Deployed-DB migrations via GH Actions | Accepted |

--- a/docs/runbooks/environments.md
+++ b/docs/runbooks/environments.md
@@ -54,6 +54,16 @@ config anywhere — add it only if a real cross-origin consumer ever appears.
 4. Use the **direct** (non-pooler) URL when running Drizzle migrations — DDL and
    session-level features don't mix with transaction pooling.
 
+### Migrations (ADR-0003)
+
+The `Migrate` workflow (`.github/workflows/migrate.yml`) applies drizzle migrations on every
+push to `staging`/`main`, using GitHub repo secrets holding each branch's **direct** Neon
+URL: `STAGING_DATABASE_URL` and `PROD_DATABASE_URL` (`gh secret set <NAME>`). No fallback
+between them; a missing secret skips green. CI's own migrate step only touches its
+throwaway Postgres container — deployed databases are migrated by this workflow alone.
+The workflow races the Vercel deploy, so migrations must stay backward-compatible with the
+previously deployed code (expand/contract).
+
 The API talks to Neon with plain `pg` over TCP — no Neon-specific driver. Fluid Compute is a
 full Node runtime, so the same driver serves Docker Postgres locally/in tests and Neon in
 deployed envs; `@neondatabase/serverless` is only for TCP-less runtimes (edge/workers) and


### PR DESCRIPTION
## Summary

Staging served an empty schema because nothing migrates the Neon databases: CI only migrates its throwaway container, and neither the Vercel build nor any workflow touched deployed DBs. Adopts paulitakes' design (ADR-0003):

- `.github/workflows/migrate.yml` — on push to `staging`/`main`, applies `pnpm db:migrate` using the branch's repo secret (`STAGING_DATABASE_URL` / `PROD_DATABASE_URL`, **direct** non-pooler URLs). No fallback between branches; missing secret logs a notice and exits green. Per-ref concurrency, no cancel.
- ADR-0003 records the decision and the accepted trade-offs (secrets duplicated into GitHub; migrate races the Vercel deploy → expand/contract discipline).
- Runbook: new Migrations section.

`PROD_DATABASE_URL` secret is already set. `STAGING_DATABASE_URL` is deliberately **not** set yet — the Preview `DATABASE_URL` currently points at the production database (provisioning bug found separately); the secret gets set once the Neon `staging` branch string is fixed.

## Test plan

- [x] Workflow YAML mirrors the proven paulitakes one (adapted to this repo's action pins + `.nvmrc`)
- [ ] Merge → `Migrate` runs on `staging` push, skips green (no staging secret yet)
- [ ] After staging DB fix + secret: re-run applies both migrations; OAuth sign-in works on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)