### PR TITLE
ci: Migrate workflow preflights DB connectivity with a readable error

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -44,6 +44,19 @@ jobs:
             echo "run=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # drizzle-kit's spinner swallows connection/auth errors (exit 1 with no
+      # message — cost a real outage diagnosis on 2026-07-22), so fail here
+      # first with the actual reason. Quoted values in psql's error (host,
+      # user) are redacted: this repo is public, so Actions logs are too.
+      - name: Connectivity preflight
+        if: steps.guard.outputs.run == 'true'
+        run: |
+          if ! err=$(psql "$DATABASE_URL" -tAc 'select 1' 2>&1 >/dev/null); then
+            echo "::error::Target database unreachable: $(printf '%s' "$err" | sed -E 's/"[^"]*"/<redacted>/g')"
+            exit 1
+          fi
+          echo "Target database reachable."
+
       - if: steps.guard.outputs.run == 'true'
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

Both Migrate failures on 2026-07-22 (PR #7 and PR #8 merges) exited 1 with no error text — drizzle-kit's spinner swallows connection failures, so a deleted Neon staging branch had to be diagnosed blind.

This adds a preflight step before \`pnpm db:migrate\`: \`psql "$DATABASE_URL" -c 'select 1'\`, failing with the real psql error. Quoted values (host, user) are redacted since this public repo has public Actions logs. Verified locally: a dead host now reports \`could not translate host name <redacted> to address\` instead of silence.

No change to migration behavior; the step runs before checkout and uses the runner's preinstalled psql.

🤖 Generated with [Claude Code](https://claude.com/claude-code)