### PR TITLE
ADM-1: admin role + admin page shell with manual job triggers (+ SIM/ADM epic merge, ADR-0011)

### DIFF
--- a/.claude/rules/engineering.md
+++ b/.claude/rules/engineering.md
@@ -60,6 +60,6 @@ Standards for all code in this repo. When a rule and `docs/architecture.md` conf
 
 ## Security
 
-- Job endpoints require the shared-secret header. Sim endpoints require the shared secret **and** are not registered when `APP_ENV=production`.
+- Job endpoints require the shared-secret header. Sim endpoints require an admin session (env-var allowlist) **and** are not registered when `APP_ENV=production` (ADR-0011) — the secret header is a jobs-only mechanism.
 - Admin capability = env-var user-ID allowlist, checked server-side; admin surfaces are invisible to non-admins.
 - Secrets and DB access are server-only; nothing secret ships in the SPA bundle. No PII beyond what OAuth provides.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -29,7 +29,7 @@ pnpm typecheck && pnpm lint && pnpm contract:check   # static gates; contract:ch
 ## Drive
 
 - The SPA consumes the generated OpenAPI client, so most behavior is verifiable straight against the API — `curl` routes per the committed spec in `openapi/openapi.json`.
-- **The simulator is the primary verification harness once SIM lands** (non-prod only): load a scenario (`POST /sim/fixtures`), set or advance time (`POST /sim/clock`), run settlement (`POST /sim/settle`), then assert via ordinary API reads. Record the shared-secret header/env-var name and scenario file locations here when SIM lands. Time-dependent behavior (locking, cutoffs, deadlines) must be verified by moving the simulated clock, never by editing kickoff timestamps. Until SIM lands, the clock offset can be set directly on the `app_state` row (`id='singleton'`, `sim_clock_offset_ms`).
+- **The simulator is the primary verification harness once SIM lands** (non-prod only): load a scenario (`POST /sim/fixtures`), set or advance time (`POST /sim/clock`), run settlement (`POST /sim/settle`), then assert via ordinary API reads. `/sim/*` is admin-session-gated (ADR-0011) — mint a session for an allowlisted user per the Auth-gated flows section below, no shared-secret header. Record the allowlist env-var name and scenario file locations here when SIM lands. Time-dependent behavior (locking, cutoffs, deadlines) must be verified by moving the simulated clock, never by editing kickoff timestamps. Until SIM lands, the clock offset can be set directly on the `app_state` row (`id='singleton'`, `sim_clock_offset_ms`).
 - DB inspection: `docker compose exec db psql -U postgres -d picksleagues` (`-d picksleagues_test` for the integration DB). Clean up synthetic rows afterward.
 
 ## Auth-gated flows

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -4,6 +4,7 @@ import { ERROR_CODE, ErrorResponseSchema } from "@picksleagues/schemas";
 import type { AppDeps } from "./deps";
 import { zodValidationHook } from "./lib/default-hook";
 import { logError } from "./lib/logger";
+import { adminRoutes } from "./routes/admin";
 import { discoveryRoutes } from "./routes/discovery";
 import { healthRoutes } from "./routes/health";
 import { jobRoutes } from "./routes/jobs";
@@ -51,6 +52,11 @@ export function createApp(deps: AppDeps = {}) {
   app.route("/", inviteRoutes(deps));
   app.route("/", memberRoutes(deps));
   app.route("/", discoveryRoutes(deps));
+
+  // Admin surface (env-var allowlist, arch §Overrides) — mounted unconditionally
+  // in every env, unlike the sim routes; server-side auth gates it, not
+  // non-registration (that's for simulator-only routes per APP_ENV=production).
+  app.route("/", adminRoutes(deps));
 
   // Better Auth owns /api/auth/* as its own typed surface (client generated
   // from the auth instance, not this OpenAPI doc) — deliberately outside the

--- a/apps/api/src/lib/nfl-sync-jobs.ts
+++ b/apps/api/src/lib/nfl-sync-jobs.ts
@@ -1,0 +1,88 @@
+import { z } from "@hono/zod-openapi";
+import type { Db } from "@picksleagues/db";
+import type { Clock, GameDataProvider } from "@picksleagues/core";
+import {
+  JOB_RUN_STATUS,
+  JobRunResponseSchema,
+  NFL_SYNC_JOB,
+  WeekTypeSchema,
+  type JobRunResponse,
+  type NflSyncJob,
+  type WeekType,
+} from "@picksleagues/schemas";
+import { syncNflSchedule } from "../services/nfl/sync-schedule";
+import { syncNflOdds } from "../services/nfl/sync-odds";
+import { syncNflScores } from "../services/nfl/sync-scores";
+
+/**
+ * Optional overrides for the manual/simulator/admin trigger path — cron fires
+ * the jobs bare and they derive season/week from the Clock, but the admin
+ * page and the simulator pass explicit values. Bounded so a typo can't
+ * request an absurd season/week. `week` is 1-based within its `weekType`
+ * (regular 1–18, postseason 1–5); an explicit `week` without `weekType`
+ * defaults to regular.
+ */
+export const SyncQuerySchema = z.object({
+  season: z.coerce.number().int().min(2000).max(2100).optional(),
+  week: z.coerce.number().int().min(1).max(18).optional(),
+  weekType: WeekTypeSchema.optional(),
+});
+
+type SyncOpts = { seasonYear?: number; weekType?: WeekType; weekNumber?: number };
+
+/**
+ * One entry per NFL sync job, shared by `/api/jobs/nfl/*` (cron, shared-secret
+ * guarded) and `/api/admin/jobs/nfl/{job}` (session+admin guarded) so both
+ * surfaces dispatch to the exact same service call. `jobName` is the string
+ * threaded into `runJob`'s envelope/logging — kept identical to the
+ * pre-existing `/jobs/nfl/*` names since logs/cron dashboards reference them.
+ */
+export const NFL_SYNC_JOBS: Record<
+  NflSyncJob,
+  {
+    jobName: string;
+    run: (
+      db: Db,
+      clock: Clock,
+      provider: GameDataProvider,
+      opts: SyncOpts,
+    ) => Promise<Record<string, string | number | boolean>>;
+  }
+> = {
+  [NFL_SYNC_JOB.SYNC_SCHEDULE]: { jobName: "nfl-sync-schedule", run: syncNflSchedule },
+  [NFL_SYNC_JOB.SYNC_ODDS]: { jobName: "nfl-sync-odds", run: syncNflOdds },
+  [NFL_SYNC_JOB.SYNC_SCORES]: { jobName: "nfl-sync-scores", run: syncNflScores },
+};
+
+/**
+ * Deviates from the me.ts idiom (which 500s with ErrorResponseSchema): job
+ * endpoints keep exactly one 500 shape in the contract — the `JobRunResponse`
+ * failure envelope — so a missing-deps 500 and a job-failure 500 are the same
+ * shape the admin page renders. Structurally unreachable outside
+ * generate-openapi.ts, which builds the app with no deps.
+ */
+export function misconfiguredJob(jobName: string): JobRunResponse {
+  return {
+    job: jobName,
+    status: JOB_RUN_STATUS.ERROR,
+    durationMs: 0,
+    message: "Database/clock/provider are not configured.",
+  };
+}
+
+/**
+ * The 200/500 response shape every NFL-sync-job route shares — `/api/jobs/*`
+ * (shared-secret guarded) and `/api/admin/jobs/*` (session+admin guarded)
+ * both dispatch through `runJob`, so both must declare the same envelope for
+ * both outcomes; each route file adds its own 400/401/403 on top.
+ */
+export const jobRunResponses = {
+  200: {
+    description: "Job completed — counters in `details`",
+    content: { "application/json": { schema: JobRunResponseSchema } },
+  },
+  500: {
+    description: "Job failed, or a dependency is not configured — same envelope either way",
+    content: { "application/json": { schema: JobRunResponseSchema } },
+  },
+} as const;

--- a/apps/api/src/lib/require-deps.ts
+++ b/apps/api/src/lib/require-deps.ts
@@ -3,6 +3,7 @@ import { ERROR_CODE, ErrorResponseSchema } from "@picksleagues/schemas";
 import type { Db } from "@picksleagues/db";
 import type { Clock } from "@picksleagues/core";
 import type { AppDeps } from "../deps";
+import { adminMiddleware } from "../middleware/admin";
 import { sessionMiddleware, type SessionVariables } from "../middleware/session";
 
 export type DepsVariables = { db: Db; clock: Clock };
@@ -51,5 +52,24 @@ export function requireSession(deps: AppDeps): MiddlewareHandler<{ Variables: Se
       );
     }
     return sessionMiddleware(deps.auth)(c, next);
+  };
+}
+
+/**
+ * Requires the caller to be in the admin allowlist. Mount after
+ * `requireSession` — depends on `sessionUser` already being on the context.
+ */
+export function requireAdmin(deps: AppDeps): MiddlewareHandler<{ Variables: SessionVariables }> {
+  return async (c, next) => {
+    if (!deps.env) {
+      return c.json(
+        ErrorResponseSchema.parse({
+          error: ERROR_CODE.MISCONFIGURED,
+          message: "Admin allowlist is not configured.",
+        }),
+        500,
+      );
+    }
+    return adminMiddleware(deps.env.ADMIN_USER_IDS)(c, next);
   };
 }

--- a/apps/api/src/lib/route-responses.ts
+++ b/apps/api/src/lib/route-responses.ts
@@ -21,6 +21,11 @@ export const NOT_COMMISSIONER_403 = {
   content: { "application/json": { schema: ErrorResponseSchema } },
 };
 
+export const NOT_ADMIN_403 = {
+  description: "The caller is signed in but not on the admin allowlist",
+  content: { "application/json": { schema: ErrorResponseSchema } },
+};
+
 export const LEAGUE_NOT_FOUND_404 = {
   description:
     "No such league, or the caller is not a member — indistinguishable so private leagues stay hidden",

--- a/apps/api/src/middleware/admin.ts
+++ b/apps/api/src/middleware/admin.ts
@@ -1,0 +1,28 @@
+import type { MiddlewareHandler } from "hono";
+import { ERROR_CODE, ErrorResponseSchema } from "@picksleagues/schemas";
+import type { SessionVariables } from "./session";
+
+/**
+ * Requires the caller's session user to be in the admin allowlist; 403s
+ * otherwise. Must run after `sessionMiddleware`/`requireSession` — reads
+ * `sessionUser` off the context rather than re-deriving it. Admin capability
+ * is the env-var user-ID allowlist (`ADMIN_USER_IDS`), not a role column
+ * (arch §Overrides).
+ */
+export function adminMiddleware(
+  adminUserIds: string[],
+): MiddlewareHandler<{ Variables: SessionVariables }> {
+  return async (c, next) => {
+    const sessionUser = c.get("sessionUser");
+    if (!adminUserIds.includes(sessionUser.id)) {
+      return c.json(
+        ErrorResponseSchema.parse({
+          error: ERROR_CODE.NOT_ADMIN,
+          message: "Admin access required.",
+        }),
+        403,
+      );
+    }
+    await next();
+  };
+}

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,0 +1,64 @@
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import { NflSyncJobSchema } from "@picksleagues/schemas";
+import type { AppDeps } from "../deps";
+import { zodValidationHook } from "../lib/default-hook";
+import { errorResponse, NOT_ADMIN_403, UNAUTHENTICATED_401 } from "../lib/route-responses";
+import {
+  jobRunResponses,
+  misconfiguredJob,
+  NFL_SYNC_JOBS,
+  SyncQuerySchema,
+} from "../lib/nfl-sync-jobs";
+import { runJob } from "../lib/job-runner";
+import { requireAdmin, requireSession } from "../lib/require-deps";
+import type { SessionVariables } from "../middleware/session";
+
+const AdminNflJobParamsSchema = z.object({ job: NflSyncJobSchema });
+
+const runAdminNflJobRoute = createRoute({
+  method: "post",
+  path: "/admin/jobs/nfl/{job}",
+  operationId: "runAdminNflJob",
+  summary: "Manually trigger an NFL data sync job",
+  request: { params: AdminNflJobParamsSchema, query: SyncQuerySchema },
+  responses: {
+    200: jobRunResponses[200],
+    400: errorResponse(
+      "Invalid job slug, or a supplied query param (season/week) fails its format rule",
+    ),
+    401: UNAUTHENTICATED_401,
+    403: NOT_ADMIN_403,
+    500: jobRunResponses[500],
+  },
+});
+
+/**
+ * Admin-triggered counterpart to `/api/jobs/nfl/*` (ADR-0011): the SPA can't
+ * hold the cron shared secret, so admins trigger the same sync jobs through a
+ * session+allowlist-guarded surface that dispatches to the identical service
+ * calls via the shared `NFL_SYNC_JOBS` registry. Mounted unconditionally in
+ * app.ts (the admin surface exists in every env; server-side allowlist gates
+ * it, not env registration).
+ */
+export function adminRoutes(deps: AppDeps) {
+  const app = new OpenAPIHono<{ Variables: SessionVariables }>({ defaultHook: zodValidationHook });
+
+  app.use("/admin/*", requireSession(deps));
+  app.use("/admin/*", requireAdmin(deps));
+
+  app.openapi(runAdminNflJobRoute, async (c) => {
+    const { db, provider, clock: resolveClock } = deps;
+    const { job } = c.req.valid("param");
+    const entry = NFL_SYNC_JOBS[job];
+    if (!db || !resolveClock || !provider) {
+      return c.json(misconfiguredJob(entry.jobName), 500);
+    }
+    const clock = await resolveClock();
+    const { season, week, weekType } = c.req.valid("query");
+    return runJob(c, entry.jobName, () =>
+      entry.run(db, clock, provider, { seasonYear: season, weekType, weekNumber: week }),
+    );
+  });
+
+  return app;
+}

--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -1,38 +1,18 @@
-import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
-import {
-  ERROR_CODE,
-  ErrorResponseSchema,
-  JOB_RUN_STATUS,
-  JobRunResponseSchema,
-  WeekTypeSchema,
-  type JobRunResponse,
-} from "@picksleagues/schemas";
+import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
+import { ERROR_CODE, ErrorResponseSchema, NFL_SYNC_JOB } from "@picksleagues/schemas";
 import type { AppDeps } from "../deps";
 import { zodValidationHook } from "../lib/default-hook";
 import { runJob } from "../lib/job-runner";
+import {
+  jobRunResponses,
+  misconfiguredJob,
+  NFL_SYNC_JOBS,
+  SyncQuerySchema,
+} from "../lib/nfl-sync-jobs";
 import { jobSecretMiddleware } from "../middleware/job-secret";
-import { syncNflSchedule } from "../services/nfl/sync-schedule";
-import { syncNflOdds } from "../services/nfl/sync-odds";
-import { syncNflScores } from "../services/nfl/sync-scores";
-
-/**
- * Optional overrides for the manual/simulator trigger path — cron fires the
- * jobs bare and they derive season/week from the Clock, but the admin page and
- * the simulator pass explicit values. Bounded so a typo can't request an
- * absurd season/week. `week` is 1-based within its `weekType` (regular 1–18,
- * postseason 1–5); an explicit `week` without `weekType` defaults to regular.
- */
-const SyncQuerySchema = z.object({
-  season: z.coerce.number().int().min(2000).max(2100).optional(),
-  week: z.coerce.number().int().min(1).max(18).optional(),
-  weekType: WeekTypeSchema.optional(),
-});
 
 const jobResponses = {
-  200: {
-    description: "Job completed — counters in `details`",
-    content: { "application/json": { schema: JobRunResponseSchema } },
-  },
+  200: jobRunResponses[200],
   400: {
     description: "A supplied query param (season/week) fails its format rule",
     content: { "application/json": { schema: ErrorResponseSchema } },
@@ -41,54 +21,40 @@ const jobResponses = {
     description: "Missing or wrong x-job-secret header",
     content: { "application/json": { schema: ErrorResponseSchema } },
   },
-  500: {
-    description: "Job failed, or a dependency is not configured — same envelope either way",
-    content: { "application/json": { schema: JobRunResponseSchema } },
-  },
+  500: jobRunResponses[500],
 } as const;
 
-const nflSyncScheduleRoute = createRoute({
-  method: "post",
-  path: "/jobs/nfl/sync-schedule",
-  operationId: "runNflSyncSchedule",
-  summary: "Ingest the NFL schedule (regular season + postseason) into our tables",
-  request: { query: SyncQuerySchema },
-  responses: jobResponses,
-});
-
-const nflSyncOddsRoute = createRoute({
-  method: "post",
-  path: "/jobs/nfl/sync-odds",
-  operationId: "runNflSyncOdds",
-  summary: "Snapshot spreads for unstarted games in the current NFL week",
-  request: { query: SyncQuerySchema },
-  responses: jobResponses,
-});
-
-const nflSyncScoresRoute = createRoute({
-  method: "post",
-  path: "/jobs/nfl/sync-scores",
-  operationId: "runNflSyncScores",
-  summary: "Refresh live scores/statuses for in-flight NFL games from the provider",
-  request: { query: SyncQuerySchema },
-  responses: jobResponses,
-});
-
 /**
- * Deviates from the me.ts idiom (which 500s with ErrorResponseSchema): job
- * endpoints keep exactly one 500 shape in the contract — the `JobRunResponse`
- * failure envelope — so a missing-deps 500 and a job-failure 500 are the same
- * shape the (future) admin page renders. Structurally unreachable outside
- * generate-openapi.ts, which builds the app with no deps.
+ * Each `/jobs/nfl/{job}` route, paths/operationIds/summaries pinned exactly
+ * as before the registry extraction — cron-job.org has these URLs configured
+ * already, and the OpenAPI contract must not shift under them.
  */
-function misconfigured(jobName: string): JobRunResponse {
-  return {
-    job: jobName,
-    status: JOB_RUN_STATUS.ERROR,
-    durationMs: 0,
-    message: "Database/clock/provider are not configured.",
-  };
-}
+const nflSyncRoutes = {
+  [NFL_SYNC_JOB.SYNC_SCHEDULE]: createRoute({
+    method: "post",
+    path: "/jobs/nfl/sync-schedule",
+    operationId: "runNflSyncSchedule",
+    summary: "Ingest the NFL schedule (regular season + postseason) into our tables",
+    request: { query: SyncQuerySchema },
+    responses: jobResponses,
+  }),
+  [NFL_SYNC_JOB.SYNC_ODDS]: createRoute({
+    method: "post",
+    path: "/jobs/nfl/sync-odds",
+    operationId: "runNflSyncOdds",
+    summary: "Snapshot spreads for unstarted games in the current NFL week",
+    request: { query: SyncQuerySchema },
+    responses: jobResponses,
+  }),
+  [NFL_SYNC_JOB.SYNC_SCORES]: createRoute({
+    method: "post",
+    path: "/jobs/nfl/sync-scores",
+    operationId: "runNflSyncScores",
+    summary: "Refresh live scores/statuses for in-flight NFL games from the provider",
+    request: { query: SyncQuerySchema },
+    responses: jobResponses,
+  }),
+} as const;
 
 /**
  * Mounts `/jobs/*` behind the shared-secret guard (DATA-4/5). Mounted
@@ -113,41 +79,20 @@ export function jobRoutes(deps: AppDeps) {
     return jobSecretMiddleware(deps.env.JOB_SECRET)(c, next);
   });
 
-  app.openapi(nflSyncScheduleRoute, async (c) => {
-    const { db, provider, clock: resolveClock } = deps;
-    if (!db || !resolveClock || !provider) {
-      return c.json(misconfigured("nfl-sync-schedule"), 500);
-    }
-    const clock = await resolveClock();
-    const { season, week, weekType } = c.req.valid("query");
-    return runJob(c, "nfl-sync-schedule", () =>
-      syncNflSchedule(db, clock, provider, { seasonYear: season, weekType, weekNumber: week }),
-    );
-  });
-
-  app.openapi(nflSyncOddsRoute, async (c) => {
-    const { db, provider, clock: resolveClock } = deps;
-    if (!db || !resolveClock || !provider) {
-      return c.json(misconfigured("nfl-sync-odds"), 500);
-    }
-    const clock = await resolveClock();
-    const { season, week, weekType } = c.req.valid("query");
-    return runJob(c, "nfl-sync-odds", () =>
-      syncNflOdds(db, clock, provider, { seasonYear: season, weekType, weekNumber: week }),
-    );
-  });
-
-  app.openapi(nflSyncScoresRoute, async (c) => {
-    const { db, provider, clock: resolveClock } = deps;
-    if (!db || !resolveClock || !provider) {
-      return c.json(misconfigured("nfl-sync-scores"), 500);
-    }
-    const clock = await resolveClock();
-    const { season, week, weekType } = c.req.valid("query");
-    return runJob(c, "nfl-sync-scores", () =>
-      syncNflScores(db, clock, provider, { seasonYear: season, weekType, weekNumber: week }),
-    );
-  });
+  for (const job of Object.values(NFL_SYNC_JOB)) {
+    const entry = NFL_SYNC_JOBS[job];
+    app.openapi(nflSyncRoutes[job], async (c) => {
+      const { db, provider, clock: resolveClock } = deps;
+      if (!db || !resolveClock || !provider) {
+        return c.json(misconfiguredJob(entry.jobName), 500);
+      }
+      const clock = await resolveClock();
+      const { season, week, weekType } = c.req.valid("query");
+      return runJob(c, entry.jobName, () =>
+        entry.run(db, clock, provider, { seasonYear: season, weekType, weekNumber: week }),
+      );
+    });
+  }
 
   return app;
 }

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -14,13 +14,14 @@ import { errorResponse, MISCONFIGURED_500, UNAUTHENTICATED_401 } from "../lib/ro
 import type { SessionVariables } from "../middleware/session";
 import { deleteAccount, getUser, updateProfile } from "../services/users";
 
-function serializeMe(user: typeof users.$inferSelect): MeResponse {
+function serializeMe(user: typeof users.$inferSelect, isAdmin: boolean): MeResponse {
   return {
     id: user.id,
     username: user.username,
     displayName: user.display_name,
     email: user.email,
     image: user.image,
+    isAdmin,
   };
 }
 
@@ -89,6 +90,10 @@ export function meRoutes(deps: AppDeps) {
   // per-handler variants.
   app.use("/me", requireDbAndClock(deps));
 
+  // Admin capability = env-var user-ID allowlist (arch §Overrides), not a role
+  // column — resolved from `deps.env` in closure so `serializeMe` stays pure.
+  const adminUserIds = deps.env?.ADMIN_USER_IDS ?? [];
+
   app.openapi(getMe, async (c) => {
     const db = c.get("db");
     const sessionUser = c.get("sessionUser");
@@ -105,7 +110,7 @@ export function meRoutes(deps: AppDeps) {
       );
     }
 
-    return c.json(serializeMe(user), 200);
+    return c.json(serializeMe(user, adminUserIds.includes(user.id)), 200);
   });
 
   app.openapi(updateMe, async (c) => {
@@ -125,7 +130,7 @@ export function meRoutes(deps: AppDeps) {
       );
     }
 
-    return c.json(serializeMe(result.user), 200);
+    return c.json(serializeMe(result.user, adminUserIds.includes(result.user.id)), 200);
   });
 
   app.openapi(deleteMe, async (c) => {

--- a/apps/api/test/admin.test.ts
+++ b/apps/api/test/admin.test.ts
@@ -1,0 +1,102 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { createDb } from "@picksleagues/db";
+import {
+  FixedClock,
+  type GameDataProvider,
+  type ProviderGame,
+  type ProviderSeasonStructure,
+  type ProviderTeam,
+} from "@picksleagues/core";
+import type { JobRunResponse } from "@picksleagues/schemas";
+import { createApp } from "../src/app";
+import { createAuth } from "../src/auth";
+import { createAuthenticatedUser } from "./setup/auth-helpers";
+import { resetDb } from "./setup/reset-db";
+import { getTestDatabaseUrl } from "./setup/test-database-url";
+import { makeTestEnv } from "./setup/test-env";
+
+const FIXED_NOW = new Date("2026-09-09T00:00:00.000Z");
+
+/** Never exercised by these tests — no games are seeded, so every sync job's
+ * fast no-op path returns before touching the provider. */
+class FakeProvider implements GameDataProvider {
+  async fetchNflSeasonStructure(): Promise<ProviderSeasonStructure> {
+    return { seasonYear: 2026, weeks: [] };
+  }
+  async fetchNflWeekGames(): Promise<ProviderGame[]> {
+    return [];
+  }
+  async fetchNflTeams(): Promise<ProviderTeam[]> {
+    return [];
+  }
+}
+
+const db = createDb(getTestDatabaseUrl());
+const provider = new FakeProvider();
+// One `auth` instance shared by every app built below — session cookies it
+// mints stay valid across them since they all share `db` and the same
+// `BETTER_AUTH_SECRET` (makeTestEnv's default); only `ADMIN_USER_IDS` varies.
+const auth = createAuth({ env: makeTestEnv(), db });
+
+function buildApp(adminUserIds: string[] = []) {
+  const env = makeTestEnv({ ADMIN_USER_IDS: adminUserIds });
+  return createApp({ auth, db, env, clock: async () => new FixedClock(FIXED_NOW), provider });
+}
+
+function postAdminJob(app: ReturnType<typeof buildApp>, job: string, cookie: string | undefined) {
+  return app.request(`/api/admin/jobs/nfl/${job}`, {
+    method: "POST",
+    headers: { ...(cookie ? { cookie } : {}) },
+  });
+}
+
+beforeEach(async () => {
+  await resetDb(db);
+});
+
+afterAll(async () => {
+  await db.$client.end();
+});
+
+describe("POST /api/admin/jobs/nfl/{job}", () => {
+  it("401s with no session cookie", async () => {
+    const app = buildApp();
+
+    const res = await postAdminJob(app, "sync-scores", undefined);
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ error: "unauthenticated" });
+  });
+
+  it("403s for an authenticated caller who isn't on the admin allowlist", async () => {
+    const app = buildApp();
+    const { cookie } = await createAuthenticatedUser(auth);
+
+    const res = await postAdminJob(app, "sync-scores", cookie);
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ error: "not_admin" });
+  });
+
+  it("400s on an invalid job slug for an admin caller", async () => {
+    const { user, cookie } = await createAuthenticatedUser(auth);
+    const app = buildApp([user.id]);
+
+    const res = await postAdminJob(app, "not-a-real-job", cookie);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("200s and runs the job for an admin-allowlisted caller", async () => {
+    const { user, cookie } = await createAuthenticatedUser(auth);
+    const app = buildApp([user.id]);
+
+    const res = await postAdminJob(app, "sync-scores", cookie);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as JobRunResponse;
+    expect(body.job).toBe("nfl-sync-scores");
+    expect(body.status).toBe("ok");
+    expect(body.details).toMatchObject({ skipped: true, reason: "no_active_games" });
+  });
+});

--- a/apps/api/test/me.test.ts
+++ b/apps/api/test/me.test.ts
@@ -97,6 +97,7 @@ describe("GET /api/me", () => {
       displayName: "Test User",
       email: user.email,
       image: null,
+      isAdmin: false,
     });
   });
 
@@ -109,6 +110,25 @@ describe("GET /api/me", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as MeResponse;
     expect(body.username).toBe("paulm");
+  });
+
+  it("200s with isAdmin true when the caller is on the ADMIN_USER_IDS allowlist", async () => {
+    const { user, cookie } = await createAuthenticatedUser(auth);
+    const adminApp = createApp({
+      auth,
+      db,
+      env: makeTestEnv({ ADMIN_USER_IDS: [user.id] }),
+      clock: async () => new FixedClock(FIXED_NOW),
+    });
+
+    const res = await adminApp.request("/api/me", {
+      method: "GET",
+      headers: { cookie },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MeResponse;
+    expect(body.isAdmin).toBe(true);
   });
 });
 
@@ -132,6 +152,7 @@ describe("PATCH /api/me", () => {
       displayName: "Test User",
       email: user.email,
       image: null,
+      isAdmin: false,
     });
 
     const [row] = await db.select().from(users).where(eq(users.id, user.id));
@@ -201,6 +222,7 @@ describe("PATCH /api/me", () => {
       displayName: "New Name",
       email: user.email,
       image: null,
+      isAdmin: false,
     });
 
     const [row] = await db.select().from(users).where(eq(users.id, user.id));
@@ -221,6 +243,7 @@ describe("PATCH /api/me", () => {
       displayName: "New Name",
       email: user.email,
       image: null,
+      isAdmin: false,
     });
   });
 

--- a/apps/api/test/setup/test-env.ts
+++ b/apps/api/test/setup/test-env.ts
@@ -5,9 +5,11 @@ import { getTestDatabaseUrl } from "./test-database-url";
  * Matches packages/core's `Env` shape without going through `loadEnv` (which
  * caches process-wide) — shared by any integration test that builds its own
  * `Auth`/`createApp` instance directly. Returns a fresh object per call so no
- * test file can mutate a shared instance out from under another.
+ * test file can mutate a shared instance out from under another. `overrides`
+ * lets a test narrow one field (e.g. `ADMIN_USER_IDS`) without restating the
+ * rest.
  */
-export function makeTestEnv(): Env {
+export function makeTestEnv(overrides?: Partial<Env>): Env {
   return {
     APP_ENV: "local",
     DATABASE_URL: getTestDatabaseUrl(),
@@ -19,5 +21,6 @@ export function makeTestEnv(): Env {
     DISCORD_CLIENT_SECRET: "discord-secret",
     JOB_SECRET: "b".repeat(32),
     ADMIN_USER_IDS: [],
+    ...overrides,
   };
 }

--- a/apps/web/src/api/admin.ts
+++ b/apps/web/src/api/admin.ts
@@ -1,0 +1,30 @@
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
+import type { NflSyncJob } from "@picksleagues/schemas";
+import { api } from "@/lib/api";
+
+// Each job row mounts its own instance and scopes pending state off
+// `mutation.variables` (async-button standard). No query invalidation: the
+// admin page doesn't read any game-data query the jobs would affect.
+export function useRunNflSyncJob() {
+  return useMutation({
+    mutationFn: async (job: NflSyncJob) => {
+      const { data, error } = await api.POST("/api/admin/jobs/nfl/{job}", {
+        params: { path: { job } },
+      });
+      if (error) {
+        // 400/401/403/500 all land here — the admin page has no per-status
+        // recovery action, so every non-2xx gets the same "go check the logs"
+        // copy rather than surfacing the wire message.
+        toast.error("Job failed — check the server logs.");
+        return null;
+      }
+      return data;
+    },
+    onSuccess: (data) => {
+      if (!data) return;
+      toast.success(`Ran ${data.job} in ${data.durationMs}ms`);
+    },
+    onError: () => toast.error("Job failed — check the server logs."),
+  });
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as AuthedRouteImport } from './routes/_authed'
 import { Route as ClaimUsernameRouteImport } from './routes/claim-username'
 import { Route as SignInRouteImport } from './routes/sign-in'
 import { Route as AuthedIndexRouteImport } from './routes/_authed/index'
+import { Route as AuthedAdminRouteImport } from './routes/_authed/admin'
 import { Route as AuthedDiscoveryRouteImport } from './routes/_authed/discovery'
 import { Route as AuthedProfileRouteImport } from './routes/_authed/profile'
 import { Route as JoinCodeRouteImport } from './routes/join.$code'
@@ -39,6 +40,11 @@ const SignInRoute = SignInRouteImport.update({
 const AuthedIndexRoute = AuthedIndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => AuthedRoute,
+} as any)
+const AuthedAdminRoute = AuthedAdminRouteImport.update({
+  id: '/admin',
+  path: '/admin',
   getParentRoute: () => AuthedRoute,
 } as any)
 const AuthedDiscoveryRoute = AuthedDiscoveryRouteImport.update({
@@ -90,6 +96,7 @@ export interface FileRoutesByFullPath {
   '/': typeof AuthedIndexRoute
   '/claim-username': typeof ClaimUsernameRoute
   '/sign-in': typeof SignInRoute
+  '/admin': typeof AuthedAdminRoute
   '/discovery': typeof AuthedDiscoveryRoute
   '/profile': typeof AuthedProfileRoute
   '/join/$code': typeof JoinCodeRoute
@@ -102,6 +109,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/claim-username': typeof ClaimUsernameRoute
   '/sign-in': typeof SignInRoute
+  '/admin': typeof AuthedAdminRoute
   '/discovery': typeof AuthedDiscoveryRoute
   '/profile': typeof AuthedProfileRoute
   '/join/$code': typeof JoinCodeRoute
@@ -116,6 +124,7 @@ export interface FileRoutesById {
   '/_authed': typeof AuthedRouteWithChildren
   '/claim-username': typeof ClaimUsernameRoute
   '/sign-in': typeof SignInRoute
+  '/_authed/admin': typeof AuthedAdminRoute
   '/_authed/discovery': typeof AuthedDiscoveryRoute
   '/_authed/profile': typeof AuthedProfileRoute
   '/join/$code': typeof JoinCodeRoute
@@ -132,6 +141,7 @@ export interface FileRouteTypes {
     | '/'
     | '/claim-username'
     | '/sign-in'
+    | '/admin'
     | '/discovery'
     | '/profile'
     | '/join/$code'
@@ -144,6 +154,7 @@ export interface FileRouteTypes {
   to:
     | '/claim-username'
     | '/sign-in'
+    | '/admin'
     | '/discovery'
     | '/profile'
     | '/join/$code'
@@ -157,6 +168,7 @@ export interface FileRouteTypes {
     | '/_authed'
     | '/claim-username'
     | '/sign-in'
+    | '/_authed/admin'
     | '/_authed/discovery'
     | '/_authed/profile'
     | '/join/$code'
@@ -203,6 +215,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof AuthedIndexRouteImport
+      parentRoute: typeof AuthedRoute
+    }
+    '/_authed/admin': {
+      id: '/_authed/admin'
+      path: '/admin'
+      fullPath: '/admin'
+      preLoaderRoute: typeof AuthedAdminRouteImport
       parentRoute: typeof AuthedRoute
     }
     '/_authed/discovery': {
@@ -283,6 +302,7 @@ const AuthedLeaguesLeagueIdRouteRouteWithChildren =
   )
 
 interface AuthedRouteChildren {
+  AuthedAdminRoute: typeof AuthedAdminRoute
   AuthedDiscoveryRoute: typeof AuthedDiscoveryRoute
   AuthedProfileRoute: typeof AuthedProfileRoute
   AuthedIndexRoute: typeof AuthedIndexRoute
@@ -291,6 +311,7 @@ interface AuthedRouteChildren {
 }
 
 const AuthedRouteChildren: AuthedRouteChildren = {
+  AuthedAdminRoute: AuthedAdminRoute,
   AuthedDiscoveryRoute: AuthedDiscoveryRoute,
   AuthedProfileRoute: AuthedProfileRoute,
   AuthedIndexRoute: AuthedIndexRoute,

--- a/apps/web/src/routes/_authed.tsx
+++ b/apps/web/src/routes/_authed.tsx
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 import { MenuIcon } from "lucide-react";
 import { authClient } from "@/lib/auth";
 import { displayNameOf, handleOf, initialsOf } from "@/lib/user";
+import { useMe } from "@/api/me";
 import { useMyLeagues } from "@/api/leagues";
 import { cn } from "@/lib/utils";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -54,6 +55,8 @@ export const Route = createFileRoute("/_authed")({
 });
 
 function AuthedLayout() {
+  const me = useMe();
+
   return (
     <div className="flex min-h-svh flex-col">
       {/* Overlays (Sheet/AlertDialog/DropdownMenu/Select, see components/ui) all
@@ -89,6 +92,16 @@ function AuthedLayout() {
               >
                 Discover
               </Link>
+              {me.data?.isAdmin && (
+                <Link
+                  to="/admin"
+                  className={navLinkClassName}
+                  inactiveProps={navLinkInactiveProps}
+                  activeProps={navLinkActiveProps}
+                >
+                  Admin
+                </Link>
+              )}
               <LeagueSwitcher />
             </nav>
           </div>
@@ -111,6 +124,7 @@ function AuthedLayout() {
 
 function MobileNav() {
   const [open, setOpen] = useState(false);
+  const me = useMe();
   const myLeagues = useMyLeagues();
   const leagues = myLeagues.data?.leagues ?? [];
 
@@ -147,6 +161,17 @@ function MobileNav() {
           >
             Discover
           </Link>
+          {me.data?.isAdmin && (
+            <Link
+              to="/admin"
+              className={drawerLinkClassName}
+              inactiveProps={navLinkInactiveProps}
+              activeProps={navLinkActiveProps}
+              onClick={() => setOpen(false)}
+            >
+              Admin
+            </Link>
+          )}
         </nav>
         {leagues.length > 0 && (
           <nav aria-label="My leagues" className="flex flex-col gap-1 text-sm">

--- a/apps/web/src/routes/_authed/admin.tsx
+++ b/apps/web/src/routes/_authed/admin.tsx
@@ -1,0 +1,117 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { NFL_SYNC_JOB, type NflSyncJob } from "@picksleagues/schemas";
+import { useMe } from "@/api/me";
+import { useRunNflSyncJob } from "@/api/admin";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export const Route = createFileRoute("/_authed/admin")({
+  component: Admin,
+});
+
+// Row copy for the three manual sync triggers — kept here rather than in the
+// api module since it's page display copy, not part of the mutation's shape.
+const NFL_SYNC_JOB_ROWS: { job: NflSyncJob; label: string; description: string }[] = [
+  {
+    job: NFL_SYNC_JOB.SYNC_SCHEDULE,
+    label: "Sync schedule",
+    description: "Weeks, games, and kickoff times.",
+  },
+  {
+    job: NFL_SYNC_JOB.SYNC_ODDS,
+    label: "Sync odds",
+    description: "Spread snapshots for games that haven't started.",
+  },
+  {
+    job: NFL_SYNC_JOB.SYNC_SCORES,
+    label: "Sync scores",
+    description: "Live and final scores.",
+  },
+];
+
+function Admin() {
+  const me = useMe();
+
+  if (me.isPending) {
+    return (
+      <main className="flex flex-1 flex-col items-center justify-center gap-2 p-4 sm:p-6">
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      </main>
+    );
+  }
+
+  if (me.isError || !me.data) {
+    return (
+      <main className="flex flex-1 flex-col items-center justify-center gap-3 p-4 sm:p-6">
+        <p className="text-sm text-muted-foreground">Couldn&apos;t load this page.</p>
+        <Button variant="outline" onClick={() => me.refetch()}>
+          Retry
+        </Button>
+      </main>
+    );
+  }
+
+  if (!me.data.isAdmin) {
+    // Admin surfaces are invisible to non-admins (engineering rules §Security)
+    // — this reads identically to an unknown route, never an "admins only"
+    // message, and never redirects (a redirect would confirm the route exists).
+    return (
+      <main className="flex flex-1 flex-col items-center justify-center py-8">
+        <p className="text-sm text-muted-foreground">Page not found.</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="flex flex-1 flex-col gap-4 p-4 sm:p-6">
+      <h1 className="text-2xl font-semibold text-foreground">Admin</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>NFL data sync</CardTitle>
+          <CardDescription>
+            Manually trigger the same sync jobs the cron scheduler runs.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3">
+          {NFL_SYNC_JOB_ROWS.map((row) => (
+            <SyncJobRow
+              key={row.job}
+              job={row.job}
+              label={row.label}
+              description={row.description}
+            />
+          ))}
+        </CardContent>
+      </Card>
+    </main>
+  );
+}
+
+function SyncJobRow({
+  job,
+  label,
+  description,
+}: {
+  job: NflSyncJob;
+  label: string;
+  description: string;
+}) {
+  const runJob = useRunNflSyncJob();
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-border p-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-0.5">
+        <p className="text-sm font-medium text-foreground">{label}</p>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={runJob.isPending && runJob.variables === job}
+        onClick={() => runJob.mutate(job)}
+      >
+        Run
+      </Button>
+    </div>
+  );
+}

--- a/backlog/04-simulator-admin.md
+++ b/backlog/04-simulator-admin.md
@@ -6,7 +6,7 @@ The UI-driven testing and operations surface, merged from the former Simulator a
 
 ## Shell & data visibility (deps already met — buildable now)
 
-- [~] **ADM-1** — Admin role via env-var user-ID allowlist + admin page shell: manual job triggers, standings rebuild buttons (as those features land); hosts the sim control panel in non-prod. _(deps: DATA-3, FND-11)_
+- [x] **ADM-1** — Admin role via env-var user-ID allowlist + admin page shell: manual job triggers, standings rebuild buttons (as those features land); hosts the sim control panel in non-prod. _(deps: DATA-3, FND-11)_
 - [ ] **ADM-4** — Read-only reference-data browsers on the admin page: teams, seasons/weeks, games (provider + override fields visible), odds snapshots. Doubles as verification for the sync jobs. _(deps: ADM-1)_
 
 ## Simulator backend

--- a/backlog/04-simulator-admin.md
+++ b/backlog/04-simulator-admin.md
@@ -1,0 +1,28 @@
+# Epic: Simulator & Admin Ops (SIM/ADM)
+
+The UI-driven testing and operations surface, merged from the former Simulator and Admin & Operations epics (ADR-0011). One admin page serves both: in all environments, data browsing, job triggers, and (post-PKM-4) overrides + audit; in non-prod, the simulator control panel — replay a real past season, advance weeks, load edge-case scenarios, reset. Ref: spec §Testing & Internal Tooling; arch §Simulator & Time, §Manual Sports Data Overrides, D13–D15.
+
+**Auth model (ADR-0011):** `/sim/*` routes are admin-session-gated (env-var user-ID allowlist) and **not registered** when `APP_ENV=production`. The shared-secret header remains for `/api/jobs/*` only. Admin surfaces are invisible to non-admins everywhere.
+
+## Shell & data visibility (deps already met — buildable now)
+
+- [~] **ADM-1** — Admin role via env-var user-ID allowlist + admin page shell: manual job triggers, standings rebuild buttons (as those features land); hosts the sim control panel in non-prod. _(deps: DATA-3, FND-11)_
+- [ ] **ADM-4** — Read-only reference-data browsers on the admin page: teams, seasons/weeks, games (provider + override fields visible), odds snapshots. Doubles as verification for the sync jobs. _(deps: ADM-1)_
+
+## Simulator backend
+
+- [ ] **SIM-1** — `sim_fixtures` tables + `SimulatedProvider`: when a scenario is loaded, the provider reads simulator-controlled data instead of ESPN-synced tables for the leagues/season under test; ESPN remains the default otherwise. _(deps: DATA-2)_
+- [ ] **SIM-2** — `POST /sim/clock`: set/advance the persisted clock offset ("advance to Week 5", jump to timestamp), consistent across serverless instances via `app_state`. _(deps: FND-6, DATA-3)_
+- [ ] **SIM-3** — `POST /sim/fixtures` (load scenario / hand-edit results) + `POST /sim/reset` (league or environment scope: truncate league/pick data, reload fixtures). _(deps: SIM-1)_
+- [ ] **SIM-6** — Past-season replay importer: load a real historical ESPN season (structure, schedule, scores) into `sim_fixtures` for replay under the simulated clock. Historical ESPN data strips odds, so spreads are synthesized into the fixtures — acceptance criterion, per ADR-0011. _(deps: SIM-1)_
+
+## Simulator UI
+
+- [ ] **SIM-7** — Sim control panel on the admin page (non-prod only): pick a season to replay (SIM-6), advance week / jump clock, load scenario, reset, and a persistent indicator of current simulated time + active scenario. _(deps: ADM-1, SIM-2, SIM-3, SIM-6)_
+- [ ] **SIM-4** — Edge-case scenario library covering the spec's required cases: pushes, ties, cancellations, postponements, week moves, all-eliminated weeks, vacated bracket slots. Acceptance bar (spec): every scoring rule and edge case is reproducible in the simulator. _(deps: SIM-3)_
+
+## Settlement-dependent tail (after PKM-4)
+
+- [ ] **SIM-5** — `POST /sim/settle`: step-through settlement for the simulated now, rendering resulting `pick_results`/`standings` inspectable per step. _(deps: SIM-2, PKM-4)_
+- [ ] **ADM-2** — Game data overrides (`PUT /admin/games/:id/override`): set/clear score, status, kickoff, spread as `override_*` parallel fields; `override_* ?? provider_*` precedence in serializers + settlement input loader; apply/clear triggers settlement recompute for affected leagues. _(deps: ADM-1, PKM-4)_
+- [ ] **ADM-3** — `admin_audit` table recording every override/rebuild (who, what, when, prior value) + audit view on the admin page. _(deps: ADM-2)_

--- a/backlog/04-simulator.md
+++ b/backlog/04-simulator.md
@@ -1,9 +1,0 @@
-# Epic: Simulator (SIM)
-
-The non-prod season simulator: simulated clock, fixture scenarios, and resets. Built before the game modes so mode work is verifiable end-to-end from day one. Ref: spec §Testing & Internal Tooling; arch §Simulator & Time, D13–D14. All routes shared-secret protected and **not registered** when `APP_ENV=production`.
-
-- [ ] **SIM-1** — `sim_fixtures` tables + `SimulatedProvider`: when a scenario is loaded, the provider reads simulator-controlled data instead of ESPN-synced tables for the leagues/season under test; ESPN remains the default otherwise. _(deps: DATA-2)_
-- [ ] **SIM-2** — `POST /sim/clock`: set/advance the persisted clock offset ("advance to Week 5", jump to timestamp), consistent across serverless instances via `app_state`. _(deps: FND-6, DATA-3)_
-- [ ] **SIM-3** — `POST /sim/fixtures` (load scenario / hand-edit results) + `POST /sim/reset` (league or environment scope: truncate league/pick data, reload fixtures). _(deps: SIM-1)_
-- [ ] **SIM-4** — Edge-case scenario library covering the spec's required cases: pushes, ties, cancellations, postponements, week moves, all-eliminated weeks, vacated bracket slots. Acceptance bar (spec): every scoring rule and edge case is reproducible in the simulator. _(deps: SIM-3)_
-- [ ] **SIM-5** — `POST /sim/settle`: step-through settlement for the simulated now, rendering resulting `pick_results`/`standings` inspectable per step. _(deps: SIM-2, PKM-4)_

--- a/backlog/08-admin-ops.md
+++ b/backlog/08-admin-ops.md
@@ -1,7 +1,0 @@
-# Epic: Admin & Operations (ADM)
-
-Operational tooling for the app admin: job triggers, data corrections, audit. Available in all environments including production. Ref: arch §Manual Sports Data Overrides, D15.
-
-- [ ] **ADM-1** — Admin role via env-var user-ID allowlist + admin page shell: manual job triggers, standings rebuild buttons; simulator controls appear in non-prod only. _(deps: DATA-3, FND-11)_
-- [ ] **ADM-2** — Game data overrides (`PUT /admin/games/:id/override`): set/clear score, status, kickoff, spread as `override_*` parallel fields; `override_* ?? provider_*` precedence in serializers + settlement input loader; apply/clear triggers settlement recompute for affected leagues. _(deps: ADM-1, PKM-4)_
-- [ ] **ADM-3** — `admin_audit` table recording every override/rebuild (who, what, when, prior value) + audit view on the admin page. _(deps: ADM-2)_

--- a/backlog/README.md
+++ b/backlog/README.md
@@ -26,12 +26,13 @@ Write tasks as **goals**: the outcome plus the `docs/mvp-spec.md` / `docs/archit
 | `01-identity.md`       | `ID`   | Username claim, profile, onboarding                         |
 | `02-game-data.md`      | `DATA` | Seasons/weeks/games schema, ESPN provider, sync jobs        |
 | `03-leagues.md`        | `LG`   | Leagues, settings, invites, membership, discovery           |
-| `04-simulator.md`      | `SIM`  | Simulated clock, fixtures, scenarios, reset                 |
+| `04-simulator-admin.md` | `SIM`/`ADM` | Admin page + simulator: data browsers, sim clock/replay UI, overrides, audit (merged per ADR-0011) |
 | `05-pickem.md`         | `PKM`  | Pick'em mode + shared settlement core (results, standings)  |
 | `06-elimination.md`    | `ELM`  | Elimination mode, survivor board                            |
 | `07-march-madness.md`  | `MM`   | Bracket ingestion, builder, scoring, pool leaderboard       |
-| `08-admin-ops.md`      | `ADM`  | Admin page, data overrides, audit, alerts                   |
 | `09-launch.md`         | `LNCH` | Rules guide, prod cron, mobile QA, launch                   |
+| `10-trust-safety.md`   | `TS`   | Post-MVP: public-league abuse resistance, member notifications |
+| `11-schema-foundations.md` | `SF` | Season/team schema scalability ahead of the picks epics    |
 
 ## Working the backlog
 

--- a/docs/adr/0011-simulator-admin-ops-merge.md
+++ b/docs/adr/0011-simulator-admin-ops-merge.md
@@ -1,0 +1,20 @@
+# 0011. Simulator & admin ops merge; UI-driven simulator with admin-session auth
+
+- **Status:** Accepted
+- **Date:** 2026-07-24
+- **Related:** mvp-spec.md §Testing & Internal Tooling; architecture.md §Environments, §Simulator & Time, §Manual Sports Data Overrides, D13–D15 (updated with this ADR); backlog `04-simulator-admin.md` (SIM-\*, ADM-\*), replaces `04-simulator.md` + `08-admin-ops.md`
+
+## Context
+
+The simulator was scoped as backend-only endpoints (shared-secret protected, curl-driven) in epic 04, while the admin page — the UI that would make them usable — sat in epic 08, after all three game modes. The owner's actual goal is an end-to-end testing surface driven from the UI: pick a real past season to replay, advance weeks, inspect and manage team/season/game/odds data. The two epics need the same admin allowlist, page shell, and data views; ADM-1 already planned to host "simulator controls in non-prod." Separately, a UI cannot hold the shared secret (nothing secret ships in the SPA bundle), so UI-driven sim control forces an auth-model decision for `/sim/*`.
+
+## Decision
+
+1. **Merge the Simulator (SIM) and Admin & Operations (ADM) epics** into one epic file, keeping both task prefixes and all existing IDs. Sequencing inside the epic: admin shell + read-only data browsers first, then sim backend + control-panel UI, then the settlement-dependent tail (overrides, audit, settle step-through) after PKM-4.
+2. **Sim routes are admin-session-gated, not shared-secret-gated.** `/sim/*` requires an authenticated session whose user ID is on the admin allowlist; the routes remain **not registered** when `APP_ENV=production` (the load-bearing gate, unchanged). The shared-secret header stays for `/api/jobs/*` only, whose callers are machines.
+3. **Provider reference data stays override-shaped or read-only in the admin UI.** Games are corrected via `override_*` fields (D15, unchanged). Teams, seasons/weeks, and odds snapshots get read-only browsers; in non-prod, data manipulation happens through sim fixtures, never by mutating provider-synced rows.
+4. **Past-season replay is a first-class simulator capability:** load a real historical ESPN season into `sim_fixtures` and replay it under the simulated clock. Historical ESPN data strips odds, so spreads for replayed seasons are synthesized into the fixtures — an acceptance criterion of the replay task, not a surprise.
+
+## Consequences
+
+Easier: the simulator is usable from day one without curl; the data browsers double as verification for the already-shipped sync jobs; one shell serves both prod ops and non-prod sim. Harder/accepted: the merged epic stays open across the Pick'em epic (its tail depends on PKM-4); admin-session auth on `/sim/*` means E2E must mint an admin session (extends the ADR-0006 minted-session approach) instead of sending a header. Revisit if a machine caller ever needs `/sim/*` (e.g. CI orchestration outside Playwright) — that caller would justify re-adding a secret-header alternative alongside session auth.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -17,3 +17,7 @@ Pre-baseline alternatives analysis lives in the architecture doc's own decision 
 | [0005](0005-tanstack-form.md)                 | TanStack Form for SPA forms          | Accepted |
 | [0006](0006-minted-session-e2e.md)            | Minted-session E2E ahead of the simulator | Accepted |
 | [0007](0007-game-data-ingestion-model.md)     | Game-data ingestion model            | Accepted |
+| [0008](0008-league-season-binding.md)         | Leagues bind to a sport season; start derived from games | Accepted (amended by 0009) |
+| [0009](0009-multi-season-leagues.md)          | Leagues span seasons via `league_seasons` instances | Accepted |
+| [0010](0010-normalized-teams.md)              | Teams are normalized reference data  | Accepted |
+| [0011](0011-simulator-admin-ops-merge.md)     | Simulator & admin ops merge; UI-driven sim, admin-session auth | Accepted |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,7 +58,7 @@ The spec's season simulator (local/staging only) drives three architectural requ
 
 **3. Step-through settlement.** Already native to the design: settlement is an idempotent endpoint over pure scoring functions, so the simulator just calls the same `settle` job per simulated week and the admin page renders resulting `pick_results` and `standings`. Recompute-from-scratch doubles as the simulator's reset for scoring state; a full environment reset truncates league/pick data and reloads fixtures.
 
-Simulator API surface (non-prod only): `POST /sim/clock` (set/advance), `POST /sim/fixtures` (load scenario / edit results), `POST /sim/settle` (run settlement for simulated now), `POST /sim/reset` (league or environment scope). All shared-secret protected on top of the env gate.
+Simulator API surface (non-prod only): `POST /sim/clock` (set/advance), `POST /sim/fixtures` (load scenario / edit results — including replaying a real past ESPN season, spreads synthesized since historical feeds strip odds), `POST /sim/settle` (run settlement for simulated now), `POST /sim/reset` (league or environment scope). Admin-session gated (env-var allowlist) on top of the env gate — the simulator is driven from the admin page, not by machine callers, so the shared-secret header stays a jobs-only mechanism (ADR-0011). E2E mints an admin session per ADR-0006.
 
 ## Automated Testing
 
@@ -76,7 +76,7 @@ Three layers, weighted by where bugs actually live (per Paulitakes experience: e
 
 ESPN's unofficial feed will occasionally be wrong (bad final score, stuck status, missed cancellation) and there is no vendor SLA — the correction path is an app-admin override, available in **all environments including production**.
 
-**Admin role:** app admins (initially just the owner) are designated by an env-var allowlist of user IDs. Admins get an admin page: job triggers, standings rebuild, and game data editing. This is operational tooling, invisible to users (they just see corrected data), and distinct from the non-prod simulator.
+**Admin role:** app admins (initially just the owner) are designated by an env-var allowlist of user IDs. Admins get an admin page: job triggers, standings rebuild, game data editing, and read-only browsers over reference data (teams, seasons/weeks, games, odds snapshots). The same page hosts the simulator control panel in non-prod (ADR-0011); overrides remain the only prod-facing edit path — provider-synced rows are never mutated directly, and teams/seasons/odds are view-only. Operational tooling is invisible to users (they just see corrected data).
 
 **Override semantics:**
 - Overridable per game: home/away final score, game status (`scheduled | final | cancelled | postponed | moved`), kickoff time, and current spread
@@ -339,7 +339,7 @@ DELETE /me                               account deletion: anonymize in place (g
 POST   /jobs/*                           secret-protected job triggers (prod cron)
 PUT    /admin/games/:id/override         set/clear overrides (admin allowlist; audited)
 POST   /admin/leagues/:id/rebuild        wipe + recompute results/standings
-POST   /sim/*                            simulator (non-prod only; see Simulator section)
+POST   /sim/*                            simulator (non-prod only, admin allowlist; see Simulator section)
 GET    /openapi.json                     generated spec
 ```
 
@@ -353,4 +353,4 @@ Generate a client for Expo/React Native (or native) directly from the OpenAPI sp
 
 ## Deliberate MVP Exclusions
 
-No websockets or push notifications (post-game freshness), no email (invite links), no matchmaking queue (H2H is post-MVP), no admin CMS (a secret-protected admin page with job triggers, rebuild buttons, and — in non-prod — simulator controls), no caching layer, no odds-provider fallback (post-MVP if ESPN's feed proves flaky).
+No websockets or push notifications (post-game freshness), no email (invite links), no matchmaking queue (H2H is post-MVP), no admin CMS (an allowlist-gated admin page with job triggers, rebuild buttons, data browsers, and — in non-prod — simulator controls), no caching layer, no odds-provider fallback (post-MVP if ESPN's feed proves flaky).

--- a/openapi/client/schema.d.ts
+++ b/openapi/client/schema.d.ts
@@ -267,6 +267,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/jobs/nfl/{job}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Manually trigger an NFL data sync job */
+        post: operations["runAdminNflJob"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -281,6 +298,7 @@ export interface components {
             displayName: string;
             email: string;
             image: string | null;
+            isAdmin: boolean;
         };
         NullableUsername: string | null;
         ErrorResponse: {
@@ -511,6 +529,8 @@ export interface components {
             /** Format: date-time */
             startsAt: string | null;
         };
+        /** @enum {string} */
+        NflSyncJob: "sync-schedule" | "sync-odds" | "sync-scores";
     };
     responses: never;
     parameters: never;
@@ -1783,6 +1803,68 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    runAdminNflJob: {
+        parameters: {
+            query?: {
+                season?: number;
+                week?: number;
+                weekType?: components["schemas"]["WeekType"];
+            };
+            header?: never;
+            path: {
+                job: components["schemas"]["NflSyncJob"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Job completed — counters in `details` */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobRunResponse"];
+                };
+            };
+            /** @description Invalid job slug, or a supplied query param (season/week) fails its format rule */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description No valid session */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The caller is signed in but not on the admin allowlist */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Job failed, or a dependency is not configured — same envelope either way */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobRunResponse"];
                 };
             };
         };

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -40,6 +40,9 @@
               "string",
               "null"
             ]
+          },
+          "isAdmin": {
+            "type": "boolean"
           }
         },
         "required": [
@@ -47,7 +50,8 @@
           "username",
           "displayName",
           "email",
-          "image"
+          "image",
+          "isAdmin"
         ]
       },
       "NullableUsername": {
@@ -961,6 +965,14 @@
           "memberCount",
           "seasonYear",
           "startsAt"
+        ]
+      },
+      "NflSyncJob": {
+        "type": "string",
+        "enum": [
+          "sync-schedule",
+          "sync-odds",
+          "sync-scores"
         ]
       }
     },
@@ -2472,6 +2484,102 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/jobs/nfl/{job}": {
+      "post": {
+        "operationId": "runAdminNflJob",
+        "summary": "Manually trigger an NFL data sync job",
+        "parameters": [
+          {
+            "schema": {
+              "$ref": "#/components/schemas/NflSyncJob"
+            },
+            "required": true,
+            "name": "job",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            },
+            "required": false,
+            "name": "season",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 18
+            },
+            "required": false,
+            "name": "week",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "$ref": "#/components/schemas/WeekType"
+            },
+            "required": false,
+            "name": "weekType",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job completed — counters in `details`",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobRunResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid job slug, or a supplied query param (season/week) fails its format rule",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No valid session",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The caller is signed in but not on the admin allowlist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Job failed, or a dependency is not configured — same envelope either way",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobRunResponse"
                 }
               }
             }

--- a/packages/schemas/src/error.ts
+++ b/packages/schemas/src/error.ts
@@ -13,6 +13,7 @@ export const ERROR_CODE = {
   INTERNAL: "internal",
   UNAUTHENTICATED: "unauthenticated",
   UNAUTHORIZED: "unauthorized",
+  NOT_ADMIN: "not_admin",
   VALIDATION: "validation",
   USERNAME_TAKEN: "username_taken",
   LAST_COMMISSIONER: "last_commissioner",

--- a/packages/schemas/src/job.ts
+++ b/packages/schemas/src/job.ts
@@ -7,6 +7,18 @@ export const JOB_RUN_STATUS = {
 
 export type JobRunStatus = (typeof JOB_RUN_STATUS)[keyof typeof JOB_RUN_STATUS];
 
+// The NFL data-sync jobs an admin can trigger manually from the admin page —
+// same set the cron scheduler fires on a timer (apps/api/src/routes/jobs.ts).
+export const NFL_SYNC_JOB = {
+  SYNC_SCHEDULE: "sync-schedule",
+  SYNC_ODDS: "sync-odds",
+  SYNC_SCORES: "sync-scores",
+} as const;
+
+export type NflSyncJob = (typeof NFL_SYNC_JOB)[keyof typeof NFL_SYNC_JOB];
+
+export const NflSyncJobSchema = z.enum(NFL_SYNC_JOB).openapi("NflSyncJob");
+
 /**
  * Uniform response envelope for every `/api/jobs/*` endpoint. `details` carries
  * per-job counters (rows upserted, transitions detected, …) — scalar values

--- a/packages/schemas/src/me.ts
+++ b/packages/schemas/src/me.ts
@@ -16,6 +16,9 @@ export const MeResponseSchema = z
     displayName: z.string(),
     email: z.string(),
     image: z.string().nullable(),
+    // Admin capability = env-var user-ID allowlist (arch §Overrides), not a
+    // role column — the SPA uses this to show/hide the admin surface.
+    isAdmin: z.boolean(),
   })
   .openapi("MeResponse");
 


### PR DESCRIPTION
## Summary

- **Epic restructure (ADR-0011):** merges the Simulator and Admin & Operations epics into `backlog/04-simulator-admin.md` — the simulator becomes a UI-driven surface hosted on the admin page (season replay, advance weeks, scenarios), `/sim/*` moves from shared-secret to admin-session auth (non-registration in prod unchanged), and `docs/architecture.md` / engineering rules are reconciled.
- **ADM-1 (API):** `requireAdmin` guard over the `ADMIN_USER_IDS` allowlist (403 `not_admin`), `isAdmin` on `GET`/`PATCH /me`, and `POST /api/admin/jobs/nfl/{job}` — session+allowlist-authed manual triggers dispatching through a shared `NFL_SYNC_JOBS` registry that the cron-facing `/api/jobs/nfl/*` routes now also consume (their contract byte-identical; verified via regen diff).
- **ADM-1 (web):** `/admin` page shell (NFL data sync card, per-row scoped run buttons per the async-button rule) + conditional Admin nav links; non-admins get a not-found state — admin surfaces stay invisible.

## Tasks
ADM-1 (`backlog/04-simulator-admin.md`) — marked done. Epic merge per ADR-0011.

## Review & tests
- Evaluator (Opus) verdict: **safe to commit** — 0 blockers; 1 stale comment fixed, 2 cosmetic notes accepted with rationale (misconfigured-path 500 shape is structurally unreachable; middleware ordering documented in JSDoc).
- `typecheck` / `lint` / `format` / `contract:check` clean · unit 171/171 · integration 211/211 (incl. new `admin.test.ts`: 401/403/400/200 matrix) · e2e 6/6.
- Live verification against the local stack: `isAdmin` on /me for admin+non-admin, 401 (no session), 403 `not_admin`, 400 (bad slug), 200 `JobRunResponse` running `nfl-sync-scores` (no-active-games fast path).

## Notes
- E2E coverage for the admin page itself needs a way to pin a minted user into `ADMIN_USER_IDS`; deferred to the sim-panel task (SIM-7) where the admin e2e harness is needed anyway.
- To use `/admin` locally: add your user ID to `ADMIN_USER_IDS` in `.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)