### PR TITLE
feat: read-only reference-data browsers on the admin page (ADM-4)

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,8 +1,22 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
-import { NflSyncJobSchema } from "@picksleagues/schemas";
+import {
+  AdminGameOddsResponseSchema,
+  AdminGamesResponseSchema,
+  AdminSeasonsResponseSchema,
+  AdminTeamsResponseSchema,
+  ERROR_CODE,
+  ErrorResponseSchema,
+  NflSyncJobSchema,
+  SportSchema,
+} from "@picksleagues/schemas";
 import type { AppDeps } from "../deps";
 import { zodValidationHook } from "../lib/default-hook";
-import { errorResponse, NOT_ADMIN_403, UNAUTHENTICATED_401 } from "../lib/route-responses";
+import {
+  errorResponse,
+  MISCONFIGURED_500,
+  NOT_ADMIN_403,
+  UNAUTHENTICATED_401,
+} from "../lib/route-responses";
 import {
   jobRunResponses,
   misconfiguredJob,
@@ -10,8 +24,14 @@ import {
   SyncQuerySchema,
 } from "../lib/nfl-sync-jobs";
 import { runJob } from "../lib/job-runner";
-import { requireAdmin, requireSession } from "../lib/require-deps";
+import {
+  requireAdmin,
+  requireDbAndClock,
+  requireSession,
+  type DepsVariables,
+} from "../lib/require-deps";
 import type { SessionVariables } from "../middleware/session";
+import { listGameOdds, listSeasons, listTeams, listWeekGames } from "../services/admin-data";
 
 const AdminNflJobParamsSchema = z.object({ job: NflSyncJobSchema });
 
@@ -32,19 +52,103 @@ const runAdminNflJobRoute = createRoute({
   },
 });
 
+// Every browser is scoped to one sport rather than defaulting to "all": a
+// second sport (NCAAMB) lands with the March Madness epic and would otherwise
+// silently double the list.
+const SportQuerySchema = z.object({ sport: SportSchema });
+
+const browserResponses = {
+  400: errorResponse("A request param failed its format rule"),
+  401: UNAUTHENTICATED_401,
+  403: NOT_ADMIN_403,
+  500: MISCONFIGURED_500,
+};
+
+const listAdminTeamsRoute = createRoute({
+  method: "get",
+  path: "/admin/teams",
+  operationId: "listAdminTeams",
+  summary: "Browse synced teams for a sport",
+  request: { query: SportQuerySchema },
+  responses: {
+    200: {
+      description: "Every team row for the sport, ordered by abbreviation",
+      content: { "application/json": { schema: AdminTeamsResponseSchema } },
+    },
+    ...browserResponses,
+  },
+});
+
+const listAdminSeasonsRoute = createRoute({
+  method: "get",
+  path: "/admin/seasons",
+  operationId: "listAdminSeasons",
+  summary: "Browse synced seasons and their weeks for a sport",
+  request: { query: SportQuerySchema },
+  responses: {
+    200: {
+      description: "Seasons newest-first, each with its weeks in chronological order",
+      content: { "application/json": { schema: AdminSeasonsResponseSchema } },
+    },
+    ...browserResponses,
+  },
+});
+
+const listAdminGamesRoute = createRoute({
+  method: "get",
+  path: "/admin/games",
+  operationId: "listAdminGames",
+  summary: "Browse a week's games with provider, override, and resolved values",
+  request: { query: z.object({ weekId: z.uuid() }) },
+  responses: {
+    200: {
+      description:
+        "The week's games ordered by resolved kickoff — empty for an unknown week id, which is indistinguishable from a week with no games synced yet",
+      content: { "application/json": { schema: AdminGamesResponseSchema } },
+    },
+    ...browserResponses,
+  },
+});
+
+const listAdminGameOddsRoute = createRoute({
+  method: "get",
+  path: "/admin/games/{gameId}/odds",
+  operationId: "listAdminGameOdds",
+  summary: "Browse a game's most recent odds snapshots",
+  request: { params: z.object({ gameId: z.uuid() }) },
+  responses: {
+    200: {
+      description: "The game's most recent spread snapshots, newest first",
+      content: { "application/json": { schema: AdminGameOddsResponseSchema } },
+    },
+    ...browserResponses,
+    404: errorResponse("No such game"),
+  },
+});
+
 /**
- * Admin-triggered counterpart to `/api/jobs/nfl/*` (ADR-0011): the SPA can't
- * hold the cron shared secret, so admins trigger the same sync jobs through a
- * session+allowlist-guarded surface that dispatches to the identical service
- * calls via the shared `NFL_SYNC_JOBS` registry. Mounted unconditionally in
- * app.ts (the admin surface exists in every env; server-side allowlist gates
- * it, not env registration).
+ * The allowlist-gated admin surface (ADR-0011): manual sync-job triggers plus
+ * the read-only reference-data browsers those triggers are verified with (arch
+ * §Manual Sports Data Overrides). Mounted unconditionally in app.ts — the admin
+ * surface exists in every env and is gated server-side by the allowlist, not by
+ * env registration (that is the simulator routes' mechanism).
+ *
+ * Triggers exist because the SPA can't hold the cron shared secret; they
+ * dispatch to the identical service calls as `/api/jobs/nfl/*` via the shared
+ * `NFL_SYNC_JOBS` registry.
  */
 export function adminRoutes(deps: AppDeps) {
-  const app = new OpenAPIHono<{ Variables: SessionVariables }>({ defaultHook: zodValidationHook });
+  const app = new OpenAPIHono<{ Variables: SessionVariables & DepsVariables }>({
+    defaultHook: zodValidationHook,
+  });
 
   app.use("/admin/*", requireSession(deps));
   app.use("/admin/*", requireAdmin(deps));
+  // Scoped to the browser routes rather than `/admin/*`: the job route resolves
+  // deps itself so its misconfiguration 500 keeps the JobRunResponse shape.
+  for (const path of ["/admin/teams", "/admin/seasons", "/admin/games", "/admin/games/*"]) {
+    app.use(path, requireDbAndClock(deps));
+  }
 
   app.openapi(runAdminNflJobRoute, async (c) => {
     const { db, provider, clock: resolveClock } = deps;
@@ -58,6 +162,33 @@ export function adminRoutes(deps: AppDeps) {
     return runJob(c, entry.jobName, () =>
       entry.run(db, clock, provider, { seasonYear: season, weekType, weekNumber: week }),
     );
+  });
+
+  app.openapi(listAdminTeamsRoute, async (c) => {
+    const { sport } = c.req.valid("query");
+    return c.json({ teams: await listTeams(c.get("db"), sport) }, 200);
+  });
+
+  app.openapi(listAdminSeasonsRoute, async (c) => {
+    const { sport } = c.req.valid("query");
+    return c.json({ seasons: await listSeasons(c.get("db"), sport) }, 200);
+  });
+
+  app.openapi(listAdminGamesRoute, async (c) => {
+    const { weekId } = c.req.valid("query");
+    return c.json({ games: await listWeekGames(c.get("db"), weekId) }, 200);
+  });
+
+  app.openapi(listAdminGameOddsRoute, async (c) => {
+    const { gameId } = c.req.valid("param");
+    const snapshots = await listGameOdds(c.get("db"), gameId);
+    if (!snapshots) {
+      return c.json(
+        ErrorResponseSchema.parse({ error: ERROR_CODE.GAME_NOT_FOUND, message: "Game not found." }),
+        404,
+      );
+    }
+    return c.json({ snapshots }, 200);
   });
 
   return app;

--- a/apps/api/src/services/admin-data.ts
+++ b/apps/api/src/services/admin-data.ts
@@ -130,7 +130,11 @@ export async function listWeekGames(db: Db, weekId: string): Promise<AdminGame[]
         rows.map((row) => row.game.id),
       ),
     )
-    .orderBy(oddsSnapshots.gameId, desc(oddsSnapshots.capturedAt));
+    // `id` breaks the tie: a sync run stamps every row it inserts with one
+    // `clock.now()`, so two snapshots for a game CAN share `captured_at`
+    // exactly (trivially so under the simulator's fixed clock) and DISTINCT ON
+    // would otherwise pick between them arbitrarily.
+    .orderBy(oddsSnapshots.gameId, desc(oddsSnapshots.capturedAt), desc(oddsSnapshots.id));
   const latestByGame = new Map(latestSnapshots.map((snapshot) => [snapshot.gameId, snapshot]));
 
   return rows.map(({ game, homeTeam, awayTeam }) => {
@@ -173,7 +177,9 @@ export async function listGameOdds(db: Db, gameId: string): Promise<AdminOddsSna
     .select()
     .from(oddsSnapshots)
     .where(eq(oddsSnapshots.gameId, gameId))
-    .orderBy(desc(oddsSnapshots.capturedAt))
+    // Same tiebreak as the latest-snapshot query above — without it, which rows
+    // survive the LIMIT boundary is arbitrary among equal `captured_at`.
+    .orderBy(desc(oddsSnapshots.capturedAt), desc(oddsSnapshots.id))
     .limit(ADMIN_ODDS_SNAPSHOT_LIMIT);
 
   return rows.map((snapshot) => ({

--- a/apps/api/src/services/admin-data.ts
+++ b/apps/api/src/services/admin-data.ts
@@ -1,0 +1,184 @@
+import { asc, count, desc, eq, inArray } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
+import type { Db } from "@picksleagues/db";
+import { games, oddsSnapshots, sportSeasons, teams, weeks } from "@picksleagues/db";
+import {
+  ADMIN_ODDS_SNAPSHOT_LIMIT,
+  type AdminGame,
+  type AdminOddsSnapshot,
+  type AdminSeason,
+  type AdminTeam,
+  type Sport,
+} from "@picksleagues/schemas";
+import { effectiveKickoffAtSql, resolveGameOverrides } from "./games";
+
+/**
+ * Queries behind the admin page's read-only reference-data browsers (arch
+ * §Manual Sports Data Overrides). Read-only by construction: nothing here
+ * writes, and the browsers double as the verification surface for the sync jobs
+ * (a week with zero games, a game with no odds snapshot, an override that
+ * survived a re-sync are all visible here).
+ *
+ * Every list is bounded by its own domain (one sport's teams, one sport's
+ * seasons, one week's games, one game's latest snapshots), so none of these
+ * paginate.
+ */
+
+export async function listTeams(db: Db, sport: Sport): Promise<AdminTeam[]> {
+  const rows = await db
+    .select()
+    .from(teams)
+    .where(eq(teams.sport, sport))
+    .orderBy(asc(teams.abbreviation));
+
+  return rows.map((team) => ({
+    id: team.id,
+    sport: team.sport,
+    providerTeamId: team.providerTeamId,
+    abbreviation: team.abbreviation,
+    name: team.name,
+    location: team.location,
+    logoLightUrl: team.logoLightUrl,
+    logoDarkUrl: team.logoDarkUrl,
+    updatedAt: team.updatedAt.toISOString(),
+  }));
+}
+
+export async function listSeasons(db: Db, sport: Sport): Promise<AdminSeason[]> {
+  const seasonRows = await db
+    .select()
+    .from(sportSeasons)
+    .where(eq(sportSeasons.sport, sport))
+    .orderBy(desc(sportSeasons.year));
+  if (seasonRows.length === 0) return [];
+
+  const seasonIds = seasonRows.map((season) => season.id);
+  const weekRows = await db
+    .select()
+    .from(weeks)
+    .where(inArray(weeks.seasonId, seasonIds))
+    // Chronological rather than by (type, number): that is the order an
+    // operator scans for a gap, and it puts postseason after regular without
+    // depending on the enum's declaration order.
+    .orderBy(asc(weeks.startsAt), asc(weeks.weekNumber));
+
+  const gameCounts =
+    weekRows.length === 0
+      ? []
+      : await db
+          .select({ weekId: games.weekId, value: count() })
+          .from(games)
+          .where(
+            inArray(
+              games.weekId,
+              weekRows.map((week) => week.id),
+            ),
+          )
+          .groupBy(games.weekId);
+  const gameCountByWeek = new Map(gameCounts.map((row) => [row.weekId, row.value]));
+
+  return seasonRows.map((season) => ({
+    id: season.id,
+    sport: season.sport,
+    year: season.year,
+    provisional: season.provisional,
+    weeks: weekRows
+      .filter((week) => week.seasonId === season.id)
+      .map((week) => ({
+        id: week.id,
+        weekType: week.weekType,
+        weekNumber: week.weekNumber,
+        label: week.label,
+        startsAt: week.startsAt.toISOString(),
+        endsAt: week.endsAt.toISOString(),
+        gameCount: gameCountByWeek.get(week.id) ?? 0,
+      })),
+  }));
+}
+
+export async function listWeekGames(db: Db, weekId: string): Promise<AdminGame[]> {
+  const homeTeams = alias(teams, "home_teams");
+  const awayTeams = alias(teams, "away_teams");
+
+  const rows = await db
+    .select({
+      game: games,
+      homeTeam: { id: homeTeams.id, abbreviation: homeTeams.abbreviation, name: homeTeams.name },
+      awayTeam: { id: awayTeams.id, abbreviation: awayTeams.abbreviation, name: awayTeams.name },
+    })
+    .from(games)
+    .innerJoin(homeTeams, eq(homeTeams.id, games.homeTeamId))
+    .innerJoin(awayTeams, eq(awayTeams.id, games.awayTeamId))
+    .where(eq(games.weekId, weekId))
+    // Ordered by the kickoff the app actually uses, so a corrected game sorts
+    // where an operator expects to find it.
+    .orderBy(asc(effectiveKickoffAtSql), asc(games.providerGameId));
+  if (rows.length === 0) return [];
+
+  // One row per game: the latest snapshot is what a browser means by "current
+  // spread" (settlement's choice of snapshot is a lock-time question, not this).
+  const latestSnapshots = await db
+    .selectDistinctOn([oddsSnapshots.gameId], {
+      gameId: oddsSnapshots.gameId,
+      spread: oddsSnapshots.spread,
+      capturedAt: oddsSnapshots.capturedAt,
+    })
+    .from(oddsSnapshots)
+    .where(
+      inArray(
+        oddsSnapshots.gameId,
+        rows.map((row) => row.game.id),
+      ),
+    )
+    .orderBy(oddsSnapshots.gameId, desc(oddsSnapshots.capturedAt));
+  const latestByGame = new Map(latestSnapshots.map((snapshot) => [snapshot.gameId, snapshot]));
+
+  return rows.map(({ game, homeTeam, awayTeam }) => {
+    const latest = latestByGame.get(game.id) ?? null;
+    const effective = resolveGameOverrides(game, latest?.spread ?? null);
+    return {
+      id: game.id,
+      weekId: game.weekId,
+      providerGameId: game.providerGameId,
+      homeTeam,
+      awayTeam,
+      kickoffAt: game.kickoffAt.toISOString(),
+      status: game.status,
+      homeScore: game.homeScore,
+      awayScore: game.awayScore,
+      latestSpread: latest?.spread ?? null,
+      latestSpreadCapturedAt: latest?.capturedAt.toISOString() ?? null,
+      overrideKickoffAt: game.overrideKickoffAt?.toISOString() ?? null,
+      overrideStatus: game.overrideStatus,
+      overrideHomeScore: game.overrideHomeScore,
+      overrideAwayScore: game.overrideAwayScore,
+      overrideSpread: game.overrideSpread,
+      overriddenBy: game.overriddenBy,
+      overriddenAt: game.overriddenAt?.toISOString() ?? null,
+      effectiveKickoffAt: effective.kickoffAt.toISOString(),
+      effectiveStatus: effective.status,
+      effectiveHomeScore: effective.homeScore,
+      effectiveAwayScore: effective.awayScore,
+      effectiveSpread: effective.spread,
+    };
+  });
+}
+
+/** Null when the game doesn't exist — distinct from a game with no snapshots yet. */
+export async function listGameOdds(db: Db, gameId: string): Promise<AdminOddsSnapshot[] | null> {
+  const [game] = await db.select({ id: games.id }).from(games).where(eq(games.id, gameId));
+  if (!game) return null;
+
+  const rows = await db
+    .select()
+    .from(oddsSnapshots)
+    .where(eq(oddsSnapshots.gameId, gameId))
+    .orderBy(desc(oddsSnapshots.capturedAt))
+    .limit(ADMIN_ODDS_SNAPSHOT_LIMIT);
+
+  return rows.map((snapshot) => ({
+    id: snapshot.id,
+    spread: snapshot.spread,
+    capturedAt: snapshot.capturedAt.toISOString(),
+  }));
+}

--- a/apps/api/src/services/games.ts
+++ b/apps/api/src/services/games.ts
@@ -1,0 +1,58 @@
+import { sql } from "drizzle-orm";
+import { games } from "@picksleagues/db";
+import type { GameStatus } from "@picksleagues/schemas";
+
+/**
+ * The single home for game override precedence (arch D15, engineering rules
+ * §Data: "override precedence is `override_* ?? provider_*`, resolved in
+ * exactly the places the architecture names — serializers + settlement input
+ * loader"). Every one of those places calls through here rather than restating
+ * the coalesce, so a correction can never be resolved one way on a read path
+ * and another way at settlement.
+ */
+
+/** The columns precedence reads — a `games` row satisfies this structurally. */
+export type GameOverrideFields = {
+  kickoffAt: Date;
+  status: GameStatus;
+  homeScore: number | null;
+  awayScore: number | null;
+  overrideKickoffAt: Date | null;
+  overrideStatus: GameStatus | null;
+  overrideHomeScore: number | null;
+  overrideAwayScore: number | null;
+  overrideSpread: number | null;
+};
+
+export type ResolvedGame = {
+  kickoffAt: Date;
+  status: GameStatus;
+  homeScore: number | null;
+  awayScore: number | null;
+  spread: number | null;
+};
+
+/**
+ * `providerSpread` is passed in rather than read off the game because the
+ * provider's spread lives in `odds_snapshots`, not on `games` — which snapshot
+ * counts (latest vs. the one current at lock time) is the caller's decision,
+ * while the override's precedence over it is not.
+ */
+export function resolveGameOverrides(
+  game: GameOverrideFields,
+  providerSpread: number | null,
+): ResolvedGame {
+  return {
+    kickoffAt: game.overrideKickoffAt ?? game.kickoffAt,
+    status: game.overrideStatus ?? game.status,
+    homeScore: game.overrideHomeScore ?? game.homeScore,
+    awayScore: game.overrideAwayScore ?? game.awayScore,
+    spread: game.overrideSpread ?? providerSpread,
+  };
+}
+
+/**
+ * SQL form of the kickoff coalesce, for the ORDER BY / WHERE clauses that must
+ * agree with `resolveGameOverrides` — kept beside it so the two can't drift.
+ */
+export const effectiveKickoffAtSql = sql<Date>`coalesce(${games.overrideKickoffAt}, ${games.kickoffAt})`;

--- a/apps/api/src/services/leagues/start.ts
+++ b/apps/api/src/services/leagues/start.ts
@@ -8,6 +8,7 @@ import {
   type LeagueSettings,
   type NflWeekRef,
 } from "@picksleagues/schemas";
+import { effectiveKickoffAtSql } from "../games";
 
 /**
  * Clock-derived league start (arch §Locking Model): the join cutoff and every
@@ -29,10 +30,9 @@ export async function leagueStartAt(
 ): Promise<Date | null> {
   // Raw SQL fragments skip drizzle's column decoders (the driver hands back a
   // string), so the aggregate maps its own value back to a Date.
-  const earliestKickoff =
-    sql`min(coalesce(${games.overrideKickoffAt}, ${games.kickoffAt}))`.mapWith(
-      (value): Date | null => (value === null ? null : new Date(value as string)),
-    );
+  const earliestKickoff = sql`min(${effectiveKickoffAtSql})`.mapWith((value): Date | null =>
+    value === null ? null : new Date(value as string),
+  );
 
   if (league.mode === LEAGUE_MODE.MARCH_MADNESS) {
     const [row] = await db

--- a/apps/api/test/admin-data.test.ts
+++ b/apps/api/test/admin-data.test.ts
@@ -95,6 +95,7 @@ async function seed(overriddenBy: string) {
       updatedAt: SEEDED_AT,
     })
     .returning();
+  if (!season2026 || !season2025) throw new Error("season insert returned no row");
   await db.insert(sportSeasons).values({
     sport: SPORT.NCAAMB,
     year: 2027,
@@ -128,6 +129,7 @@ async function seed(overriddenBy: string) {
       },
     ])
     .returning();
+  if (!week1 || !week2) throw new Error("week insert returned no row");
 
   const [buf, mia, ne, nyj] = await db
     .insert(teams)
@@ -191,6 +193,7 @@ async function seed(overriddenBy: string) {
       },
     ])
     .returning();
+  if (!buf || !mia || !ne || !nyj) throw new Error("team insert returned no row");
 
   const [gameA, gameB] = await db
     .insert(games)
@@ -228,6 +231,7 @@ async function seed(overriddenBy: string) {
       },
     ])
     .returning();
+  if (!gameA || !gameB) throw new Error("game insert returned no row");
 
   // Two snapshots on A (the later one is what "current spread" means) and none
   // on B, whose spread therefore comes entirely from its override.
@@ -322,11 +326,12 @@ describe("GET /api/admin/seasons", () => {
     expect(res.status).toBe(200);
     const { seasons } = (await res.json()) as AdminSeasonsResponse;
     expect(seasons.map((season) => season.year)).toEqual([2026, 2025]);
-    expect(seasons[0]).toMatchObject({ sport: "nfl", provisional: false });
-    expect(seasons[1]).toMatchObject({ year: 2025, provisional: true, weeks: [] });
+    const [current, previous] = seasons;
+    expect(current).toMatchObject({ sport: "nfl", provisional: false });
+    expect(previous).toMatchObject({ year: 2025, provisional: true, weeks: [] });
 
-    expect(seasons[0].weeks.map((week) => week.label)).toEqual(["Week 1", "Week 2"]);
-    expect(seasons[0].weeks[0]).toMatchObject({
+    expect(current?.weeks.map((week) => week.label)).toEqual(["Week 1", "Week 2"]);
+    expect(current?.weeks[0]).toMatchObject({
       weekType: "regular",
       weekNumber: 1,
       startsAt: "2026-09-08T00:00:00.000Z",
@@ -334,7 +339,7 @@ describe("GET /api/admin/seasons", () => {
       gameCount: 2,
     });
     // The sync-failure signal the browser exists for: a synced week with no games.
-    expect(seasons[0].weeks[1].gameCount).toBe(0);
+    expect(current?.weeks[1]?.gameCount).toBe(0);
   });
 });
 
@@ -457,7 +462,7 @@ describe("GET /api/admin/games/{gameId}/odds", () => {
     expect(res.status).toBe(200);
     const { snapshots } = (await res.json()) as AdminGameOddsResponse;
     expect(snapshots.map((snapshot) => snapshot.spread)).toEqual([-2.5, -3.5]);
-    expect(snapshots[0].capturedAt).toBe("2026-09-12T12:00:00.000Z");
+    expect(snapshots[0]?.capturedAt).toBe("2026-09-12T12:00:00.000Z");
   });
 
   it("distinguishes a game with no snapshots from a missing game", async () => {
@@ -468,5 +473,49 @@ describe("GET /api/admin/games/{gameId}/odds", () => {
 
     expect(res.status).toBe(200);
     expect((await res.json()) as AdminGameOddsResponse).toEqual({ snapshots: [] });
+  });
+});
+
+describe("snapshots captured at the same instant", () => {
+  /**
+   * A sync run stamps every row it inserts with one `clock.now()`, so equal
+   * `captured_at` values are ordinary — and under the simulator's fixed clock
+   * they are the norm. Both snapshot reads must still be deterministic.
+   */
+  async function seedTiedSnapshots(userId: string) {
+    const seeded = await seed(userId);
+    const tiedAt = new Date("2026-09-13T12:00:00.000Z");
+    const rows = await db
+      .insert(oddsSnapshots)
+      .values([
+        { gameId: seeded.gameA.id, spread: 1.5, capturedAt: tiedAt, createdAt: SEEDED_AT },
+        { gameId: seeded.gameA.id, spread: 2.5, capturedAt: tiedAt, createdAt: SEEDED_AT },
+      ])
+      .returning();
+    const winner = [...rows].sort((a, b) => (a.id < b.id ? 1 : -1))[0];
+    if (!winner) throw new Error("snapshot insert returned no row");
+    return { seeded, winner };
+  }
+
+  it("resolves the latest spread deterministically", async () => {
+    const { app, cookie, userId } = await adminCaller();
+    const { seeded, winner } = await seedTiedSnapshots(userId);
+
+    const res = await get(app, `/api/admin/games?weekId=${seeded.week1.id}`, cookie);
+
+    const { games: rows } = (await res.json()) as AdminGamesResponse;
+    const gameA = rows.find((game) => game.providerGameId === "evt-a");
+    expect(gameA?.latestSpread).toBe(winner.spread);
+    expect(gameA?.effectiveSpread).toBe(winner.spread);
+  });
+
+  it("orders the snapshot history deterministically", async () => {
+    const { app, cookie, userId } = await adminCaller();
+    const { seeded, winner } = await seedTiedSnapshots(userId);
+
+    const res = await get(app, `/api/admin/games/${seeded.gameA.id}/odds`, cookie);
+
+    const { snapshots } = (await res.json()) as AdminGameOddsResponse;
+    expect(snapshots[0]?.id).toBe(winner.id);
   });
 });

--- a/apps/api/test/admin-data.test.ts
+++ b/apps/api/test/admin-data.test.ts
@@ -1,0 +1,472 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { createDb, games, oddsSnapshots, sportSeasons, teams, weeks } from "@picksleagues/db";
+import {
+  FixedClock,
+  type GameDataProvider,
+  type ProviderGame,
+  type ProviderSeasonStructure,
+  type ProviderTeam,
+} from "@picksleagues/core";
+import {
+  GAME_STATUS,
+  SPORT,
+  WEEK_TYPE,
+  type AdminGameOddsResponse,
+  type AdminGamesResponse,
+  type AdminSeasonsResponse,
+  type AdminTeamsResponse,
+} from "@picksleagues/schemas";
+import { createApp } from "../src/app";
+import { createAuth } from "../src/auth";
+import { createAuthenticatedUser } from "./setup/auth-helpers";
+import { resetDb } from "./setup/reset-db";
+import { getTestDatabaseUrl } from "./setup/test-database-url";
+import { makeTestEnv } from "./setup/test-env";
+
+// The browsers are pure reads — nothing here consults the clock, so a fixed
+// instant only exists to satisfy createApp's dep.
+const FIXED_NOW = new Date("2026-09-12T00:00:00.000Z");
+const SEEDED_AT = new Date("2026-09-01T00:00:00.000Z");
+
+/** Never called — no route under test touches the provider. */
+class FakeProvider implements GameDataProvider {
+  async fetchNflSeasonStructure(): Promise<ProviderSeasonStructure> {
+    return { seasonYear: 2026, weeks: [] };
+  }
+  async fetchNflWeekGames(): Promise<ProviderGame[]> {
+    return [];
+  }
+  async fetchNflTeams(): Promise<ProviderTeam[]> {
+    return [];
+  }
+}
+
+const db = createDb(getTestDatabaseUrl());
+const auth = createAuth({ env: makeTestEnv(), db });
+
+function buildApp(adminUserIds: string[] = []) {
+  const env = makeTestEnv({ ADMIN_USER_IDS: adminUserIds });
+  return createApp({
+    auth,
+    db,
+    env,
+    clock: async () => new FixedClock(FIXED_NOW),
+    provider: new FakeProvider(),
+  });
+}
+
+function get(app: ReturnType<typeof buildApp>, path: string, cookie?: string) {
+  return app.request(path, { headers: { ...(cookie ? { cookie } : {}) } });
+}
+
+/** Signs in a user, puts them on the allowlist, and returns an admin-ready app. */
+async function adminCaller() {
+  const { user, cookie } = await createAuthenticatedUser(auth);
+  return { app: buildApp([user.id]), cookie, userId: user.id };
+}
+
+/**
+ * One NFL season with an overridden game, plus a second season and an NCAAMB
+ * row so sport filtering and season ordering are observable. `overriddenBy`
+ * comes from the caller because the FK points at a real user row.
+ *
+ * The override is deliberately shaped so provider order and resolved order
+ * DISAGREE: game B kicks off first per the provider but last once its
+ * `override_kickoff_at` applies.
+ */
+async function seed(overriddenBy: string) {
+  const [season2026] = await db
+    .insert(sportSeasons)
+    .values({
+      sport: SPORT.NFL,
+      year: 2026,
+      provisional: false,
+      createdAt: SEEDED_AT,
+      updatedAt: SEEDED_AT,
+    })
+    .returning();
+  const [season2025] = await db
+    .insert(sportSeasons)
+    .values({
+      sport: SPORT.NFL,
+      year: 2025,
+      provisional: true,
+      createdAt: SEEDED_AT,
+      updatedAt: SEEDED_AT,
+    })
+    .returning();
+  await db.insert(sportSeasons).values({
+    sport: SPORT.NCAAMB,
+    year: 2027,
+    provisional: false,
+    createdAt: SEEDED_AT,
+    updatedAt: SEEDED_AT,
+  });
+
+  const [week1, week2] = await db
+    .insert(weeks)
+    .values([
+      {
+        seasonId: season2026.id,
+        weekType: WEEK_TYPE.REGULAR,
+        weekNumber: 1,
+        label: "Week 1",
+        startsAt: new Date("2026-09-08T00:00:00.000Z"),
+        endsAt: new Date("2026-09-15T00:00:00.000Z"),
+        createdAt: SEEDED_AT,
+        updatedAt: SEEDED_AT,
+      },
+      {
+        seasonId: season2026.id,
+        weekType: WEEK_TYPE.REGULAR,
+        weekNumber: 2,
+        label: "Week 2",
+        startsAt: new Date("2026-09-15T00:00:00.000Z"),
+        endsAt: new Date("2026-09-22T00:00:00.000Z"),
+        createdAt: SEEDED_AT,
+        updatedAt: SEEDED_AT,
+      },
+    ])
+    .returning();
+
+  const [buf, mia, ne, nyj] = await db
+    .insert(teams)
+    .values([
+      {
+        sport: SPORT.NFL,
+        providerTeamId: "2",
+        abbreviation: "BUF",
+        name: "Bills",
+        location: "Buffalo",
+        logoLightUrl: "https://example.test/buf.png",
+        logoDarkUrl: null,
+        createdAt: SEEDED_AT,
+        updatedAt: SEEDED_AT,
+      },
+      {
+        sport: SPORT.NFL,
+        providerTeamId: "15",
+        abbreviation: "MIA",
+        name: "Dolphins",
+        location: "Miami",
+        logoLightUrl: null,
+        logoDarkUrl: null,
+        createdAt: SEEDED_AT,
+        updatedAt: SEEDED_AT,
+      },
+      // Bootstrap row: no provider id yet, no enriched metadata — the exact
+      // state an operator browses this list to spot.
+      {
+        sport: SPORT.NFL,
+        providerTeamId: null,
+        abbreviation: "NE",
+        name: "Patriots",
+        location: null,
+        logoLightUrl: null,
+        logoDarkUrl: null,
+        createdAt: SEEDED_AT,
+        updatedAt: SEEDED_AT,
+      },
+      {
+        sport: SPORT.NFL,
+        providerTeamId: "20",
+        abbreviation: "NYJ",
+        name: "Jets",
+        location: "New York",
+        logoLightUrl: null,
+        logoDarkUrl: null,
+        createdAt: SEEDED_AT,
+        updatedAt: SEEDED_AT,
+      },
+      {
+        sport: SPORT.NCAAMB,
+        providerTeamId: "150",
+        abbreviation: "DUKE",
+        name: "Blue Devils",
+        location: "Durham",
+        logoLightUrl: null,
+        logoDarkUrl: null,
+        createdAt: SEEDED_AT,
+        updatedAt: SEEDED_AT,
+      },
+    ])
+    .returning();
+
+  const [gameA, gameB] = await db
+    .insert(games)
+    .values([
+      {
+        weekId: week1.id,
+        providerGameId: "evt-a",
+        homeTeamId: buf.id,
+        awayTeamId: nyj.id,
+        kickoffAt: new Date("2026-09-14T20:00:00.000Z"),
+        status: GAME_STATUS.SCHEDULED,
+        homeScore: null,
+        awayScore: null,
+        createdAt: SEEDED_AT,
+        updatedAt: SEEDED_AT,
+      },
+      {
+        weekId: week1.id,
+        providerGameId: "evt-b",
+        homeTeamId: ne.id,
+        awayTeamId: mia.id,
+        kickoffAt: new Date("2026-09-13T17:00:00.000Z"),
+        status: GAME_STATUS.IN_PROGRESS,
+        homeScore: 21,
+        awayScore: 21,
+        overrideKickoffAt: new Date("2026-09-14T23:00:00.000Z"),
+        overrideStatus: GAME_STATUS.FINAL,
+        overrideHomeScore: 24,
+        overrideAwayScore: 21,
+        overrideSpread: 7.5,
+        overriddenBy,
+        overriddenAt: new Date("2026-09-14T23:30:00.000Z"),
+        createdAt: SEEDED_AT,
+        updatedAt: SEEDED_AT,
+      },
+    ])
+    .returning();
+
+  // Two snapshots on A (the later one is what "current spread" means) and none
+  // on B, whose spread therefore comes entirely from its override.
+  await db.insert(oddsSnapshots).values([
+    {
+      gameId: gameA.id,
+      spread: -3.5,
+      capturedAt: new Date("2026-09-10T12:00:00.000Z"),
+      createdAt: SEEDED_AT,
+    },
+    {
+      gameId: gameA.id,
+      spread: -2.5,
+      capturedAt: new Date("2026-09-12T12:00:00.000Z"),
+      createdAt: SEEDED_AT,
+    },
+  ]);
+
+  return { season2026, season2025, week1, week2, gameA, gameB };
+}
+
+beforeEach(async () => {
+  await resetDb(db);
+});
+
+afterAll(async () => {
+  await db.$client.end();
+});
+
+describe("admin reference-data browsers", () => {
+  const paths = [
+    "/api/admin/teams?sport=nfl",
+    "/api/admin/seasons?sport=nfl",
+    "/api/admin/games?weekId=00000000-0000-4000-8000-000000000000",
+    "/api/admin/games/00000000-0000-4000-8000-000000000000/odds",
+  ];
+
+  it.each(paths)("401s with no session cookie: %s", async (path) => {
+    const res = await get(buildApp(), path);
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ error: "unauthenticated" });
+  });
+
+  it.each(paths)("403s for a signed-in caller off the allowlist: %s", async (path) => {
+    const { cookie } = await createAuthenticatedUser(auth);
+
+    const res = await get(buildApp(), path, cookie);
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ error: "not_admin" });
+  });
+});
+
+describe("GET /api/admin/teams", () => {
+  it("400s without the required sport param", async () => {
+    const { app, cookie } = await adminCaller();
+
+    const res = await get(app, "/api/admin/teams", cookie);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns one sport's teams by abbreviation, preserving unlinked rows", async () => {
+    const { app, cookie, userId } = await adminCaller();
+    await seed(userId);
+
+    const res = await get(app, "/api/admin/teams?sport=nfl", cookie);
+
+    expect(res.status).toBe(200);
+    const { teams: rows } = (await res.json()) as AdminTeamsResponse;
+    expect(rows.map((team) => team.abbreviation)).toEqual(["BUF", "MIA", "NE", "NYJ"]);
+    expect(rows[0]).toMatchObject({
+      sport: "nfl",
+      providerTeamId: "2",
+      name: "Bills",
+      location: "Buffalo",
+      logoLightUrl: "https://example.test/buf.png",
+      logoDarkUrl: null,
+    });
+    expect(rows[2]).toMatchObject({ abbreviation: "NE", providerTeamId: null, location: null });
+  });
+});
+
+describe("GET /api/admin/seasons", () => {
+  it("returns seasons newest-first with chronological weeks and game counts", async () => {
+    const { app, cookie, userId } = await adminCaller();
+    await seed(userId);
+
+    const res = await get(app, "/api/admin/seasons?sport=nfl", cookie);
+
+    expect(res.status).toBe(200);
+    const { seasons } = (await res.json()) as AdminSeasonsResponse;
+    expect(seasons.map((season) => season.year)).toEqual([2026, 2025]);
+    expect(seasons[0]).toMatchObject({ sport: "nfl", provisional: false });
+    expect(seasons[1]).toMatchObject({ year: 2025, provisional: true, weeks: [] });
+
+    expect(seasons[0].weeks.map((week) => week.label)).toEqual(["Week 1", "Week 2"]);
+    expect(seasons[0].weeks[0]).toMatchObject({
+      weekType: "regular",
+      weekNumber: 1,
+      startsAt: "2026-09-08T00:00:00.000Z",
+      endsAt: "2026-09-15T00:00:00.000Z",
+      gameCount: 2,
+    });
+    // The sync-failure signal the browser exists for: a synced week with no games.
+    expect(seasons[0].weeks[1].gameCount).toBe(0);
+  });
+});
+
+describe("GET /api/admin/games", () => {
+  it("400s on a non-uuid week id", async () => {
+    const { app, cookie } = await adminCaller();
+
+    const res = await get(app, "/api/admin/games?weekId=not-a-uuid", cookie);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns [] for a week with no games", async () => {
+    const { app, cookie, userId } = await adminCaller();
+    const seeded = await seed(userId);
+
+    const res = await get(app, `/api/admin/games?weekId=${seeded.week2.id}`, cookie);
+
+    expect(res.status).toBe(200);
+    expect((await res.json()) as AdminGamesResponse).toEqual({ games: [] });
+  });
+
+  it("orders by resolved kickoff, not the provider's", async () => {
+    const { app, cookie, userId } = await adminCaller();
+    const seeded = await seed(userId);
+
+    const res = await get(app, `/api/admin/games?weekId=${seeded.week1.id}`, cookie);
+
+    const { games: rows } = (await res.json()) as AdminGamesResponse;
+    // Provider kickoffs would order these B, A — the override flips it.
+    expect(rows.map((game) => game.providerGameId)).toEqual(["evt-a", "evt-b"]);
+  });
+
+  it("serializes provider fields untouched alongside the override-resolved ones", async () => {
+    const { app, cookie, userId } = await adminCaller();
+    const seeded = await seed(userId);
+
+    const res = await get(app, `/api/admin/games?weekId=${seeded.week1.id}`, cookie);
+
+    const { games: rows } = (await res.json()) as AdminGamesResponse;
+    const overridden = rows.find((game) => game.providerGameId === "evt-b");
+    expect(overridden).toMatchObject({
+      // Provider block survives the correction verbatim (arch D15).
+      kickoffAt: "2026-09-13T17:00:00.000Z",
+      status: "in_progress",
+      homeScore: 21,
+      awayScore: 21,
+      // Override block as stored.
+      overrideKickoffAt: "2026-09-14T23:00:00.000Z",
+      overrideStatus: "final",
+      overrideHomeScore: 24,
+      overrideAwayScore: 21,
+      overrideSpread: 7.5,
+      overriddenBy: userId,
+      overriddenAt: "2026-09-14T23:30:00.000Z",
+      // Resolved = override ?? provider.
+      effectiveKickoffAt: "2026-09-14T23:00:00.000Z",
+      effectiveStatus: "final",
+      effectiveHomeScore: 24,
+      effectiveAwayScore: 21,
+      effectiveSpread: 7.5,
+      // No snapshot exists — the effective spread came from the override alone.
+      latestSpread: null,
+      latestSpreadCapturedAt: null,
+      homeTeam: { abbreviation: "NE", name: "Patriots" },
+      awayTeam: { abbreviation: "MIA", name: "Dolphins" },
+    });
+  });
+
+  it("falls back to provider values and the latest snapshot when nothing is overridden", async () => {
+    const { app, cookie, userId } = await adminCaller();
+    const seeded = await seed(userId);
+
+    const res = await get(app, `/api/admin/games?weekId=${seeded.week1.id}`, cookie);
+
+    const { games: rows } = (await res.json()) as AdminGamesResponse;
+    const clean = rows.find((game) => game.providerGameId === "evt-a");
+    expect(clean).toMatchObject({
+      overrideKickoffAt: null,
+      overrideStatus: null,
+      overrideHomeScore: null,
+      overrideAwayScore: null,
+      overrideSpread: null,
+      overriddenBy: null,
+      overriddenAt: null,
+      effectiveKickoffAt: "2026-09-14T20:00:00.000Z",
+      effectiveStatus: "scheduled",
+      effectiveHomeScore: null,
+      effectiveAwayScore: null,
+      // Newest snapshot wins, and with no override it is also the effective spread.
+      latestSpread: -2.5,
+      latestSpreadCapturedAt: "2026-09-12T12:00:00.000Z",
+      effectiveSpread: -2.5,
+      homeTeam: { abbreviation: "BUF", name: "Bills" },
+      awayTeam: { abbreviation: "NYJ", name: "Jets" },
+    });
+  });
+});
+
+describe("GET /api/admin/games/{gameId}/odds", () => {
+  it("404s for an unknown game", async () => {
+    const { app, cookie } = await adminCaller();
+
+    const res = await get(
+      app,
+      "/api/admin/games/00000000-0000-4000-8000-000000000000/odds",
+      cookie,
+    );
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ error: "game_not_found" });
+  });
+
+  it("returns snapshots newest-first", async () => {
+    const { app, cookie, userId } = await adminCaller();
+    const seeded = await seed(userId);
+
+    const res = await get(app, `/api/admin/games/${seeded.gameA.id}/odds`, cookie);
+
+    expect(res.status).toBe(200);
+    const { snapshots } = (await res.json()) as AdminGameOddsResponse;
+    expect(snapshots.map((snapshot) => snapshot.spread)).toEqual([-2.5, -3.5]);
+    expect(snapshots[0].capturedAt).toBe("2026-09-12T12:00:00.000Z");
+  });
+
+  it("distinguishes a game with no snapshots from a missing game", async () => {
+    const { app, cookie, userId } = await adminCaller();
+    const seeded = await seed(userId);
+
+    const res = await get(app, `/api/admin/games/${seeded.gameB.id}/odds`, cookie);
+
+    expect(res.status).toBe(200);
+    expect((await res.json()) as AdminGameOddsResponse).toEqual({ snapshots: [] });
+  });
+});

--- a/apps/web/src/api/admin.ts
+++ b/apps/web/src/api/admin.ts
@@ -1,12 +1,20 @@
-import { useMutation } from "@tanstack/react-query";
+import { skipToken, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import type { NflSyncJob } from "@picksleagues/schemas";
+import type { NflSyncJob, Sport } from "@picksleagues/schemas";
 import { api } from "@/lib/api";
 
+// One home for the admin cache-key shape: every browser query below is
+// prefixed with this, so a single invalidation after a sync job covers all
+// four without the run-job hook restating the key literal.
+const ADMIN_QUERY_KEY_PREFIX = ["admin"];
+
 // Each job row mounts its own instance and scopes pending state off
-// `mutation.variables` (async-button standard). No query invalidation: the
-// admin page doesn't read any game-data query the jobs would affect.
+// `mutation.variables` (async-button standard). SyncJobsCard, SeasonsBrowser,
+// GamesBrowser, and TeamsBrowser are siblings on the same admin page reading
+// exactly the tables these jobs write, so a successful run invalidates all
+// four — otherwise a real sync and a no-op look identical to the operator.
 export function useRunNflSyncJob() {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (job: NflSyncJob) => {
       const { data, error } = await api.POST("/api/admin/jobs/nfl/{job}", {
@@ -21,10 +29,91 @@ export function useRunNflSyncJob() {
       }
       return data;
     },
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data) return;
       toast.success(`Ran ${data.job} in ${data.durationMs}ms`);
+      await queryClient.invalidateQueries({ queryKey: ADMIN_QUERY_KEY_PREFIX });
     },
     onError: () => toast.error("Job failed — check the server logs."),
+  });
+}
+
+// The four read-only browsers below are inspection surfaces (arch §Manual
+// Sports Data Overrides) — plain queries, no mutation/toast wiring.
+
+export function adminTeamsQueryKey(sport: Sport) {
+  return [...ADMIN_QUERY_KEY_PREFIX, "teams", sport];
+}
+
+export function useAdminTeams(sport: Sport) {
+  return useQuery({
+    queryKey: adminTeamsQueryKey(sport),
+    queryFn: async () => {
+      const { data, error } = await api.GET("/api/admin/teams", {
+        params: { query: { sport } },
+      });
+      if (error) throw error;
+      return data;
+    },
+  });
+}
+
+export function adminSeasonsQueryKey(sport: Sport) {
+  return [...ADMIN_QUERY_KEY_PREFIX, "seasons", sport];
+}
+
+export function useAdminSeasons(sport: Sport) {
+  return useQuery({
+    queryKey: adminSeasonsQueryKey(sport),
+    queryFn: async () => {
+      const { data, error } = await api.GET("/api/admin/seasons", {
+        params: { query: { sport } },
+      });
+      if (error) throw error;
+      return data;
+    },
+  });
+}
+
+export function adminGamesQueryKey(weekId: string | undefined) {
+  return [...ADMIN_QUERY_KEY_PREFIX, "games", weekId];
+}
+
+// `skipToken` rather than `enabled` for the not-yet-selected week: it narrows
+// `weekId` to a string inside the queryFn, so the required query param needs no
+// non-null assertion.
+export function useAdminGames(weekId: string | undefined) {
+  return useQuery({
+    queryKey: adminGamesQueryKey(weekId),
+    queryFn: weekId
+      ? async () => {
+          const { data, error } = await api.GET("/api/admin/games", {
+            params: { query: { weekId } },
+          });
+          if (error) throw error;
+          return data;
+        }
+      : skipToken,
+  });
+}
+
+export function adminGameOddsQueryKey(gameId: string) {
+  return [...ADMIN_QUERY_KEY_PREFIX, "games", gameId, "odds"];
+}
+
+// Odds history is expensive relative to the other browsers (a query per
+// game) so it's opt-in: the games browser only enables this once a game's
+// disclosure is opened.
+export function useAdminGameOdds(gameId: string, enabled: boolean) {
+  return useQuery({
+    queryKey: adminGameOddsQueryKey(gameId),
+    queryFn: async () => {
+      const { data, error } = await api.GET("/api/admin/games/{gameId}/odds", {
+        params: { path: { gameId } },
+      });
+      if (error) throw error;
+      return data;
+    },
+    enabled,
   });
 }

--- a/apps/web/src/components/admin/games-browser.tsx
+++ b/apps/web/src/components/admin/games-browser.tsx
@@ -31,17 +31,35 @@ function isOverridden(game: AdminGame) {
   );
 }
 
-export function GamesBrowser() {
+/**
+ * Selection lives in the URL (owned by the route), not in state: a specific
+ * week's slate is worth sharing while debugging a sync, and it survives a
+ * refresh. Both params are optional — an absent one derives to the newest
+ * season and its earliest week (seasons arrive newest-first, weeks
+ * chronological), so the browser opens on something useful with no effect-driven
+ * setState cascade.
+ */
+export function GamesBrowser({
+  seasonId,
+  weekId,
+  onSeasonChange,
+  onWeekChange,
+}: {
+  seasonId?: string;
+  weekId?: string;
+  onSeasonChange: (seasonId: string) => void;
+  onWeekChange: (weekId: string) => void;
+}) {
   const seasons = useAdminSeasons(SPORT.NFL);
-  // `undefined` means "no explicit choice yet" — derived below to the newest
-  // season / its earliest week (seasons arrive newest-first, weeks
-  // chronological) so the browser opens on the current week without an
-  // effect-driven setState render cascade.
-  const [seasonId, setSeasonId] = useState<string | undefined>();
-  const [weekId, setWeekId] = useState<string | undefined>();
 
-  const effectiveSeasonId = seasonId ?? seasons.data?.seasons[0]?.id;
-  const selectedSeason = seasons.data?.seasons.find((season) => season.id === effectiveSeasonId);
+  const all = seasons.data?.seasons ?? [];
+  // A week identifies its own season, so an inbound link needs only `weekId`
+  // and `seasonId` is the fallback for "a season is chosen but no week yet"
+  // (which is also how a season with zero weeks stays selected).
+  const selectedSeason =
+    all.find((season) => season.weeks.some((week) => week.id === weekId)) ??
+    all.find((season) => season.id === seasonId) ??
+    all[0];
   const effectiveWeekId = weekId ?? selectedSeason?.weeks[0]?.id;
   const games = useAdminGames(effectiveWeekId);
 
@@ -59,7 +77,7 @@ export function GamesBrowser() {
           isError={seasons.isError}
           onRetry={() => seasons.refetch()}
           errorMessage="Couldn't load seasons."
-          isEmpty={seasons.data?.seasons.length === 0}
+          isEmpty={all.length === 0}
           emptyMessage="No seasons synced yet."
         >
           <div className="flex flex-col gap-4">
@@ -67,14 +85,11 @@ export function GamesBrowser() {
               <LabeledSelect
                 id="games-browser-season"
                 label="Season"
-                value={effectiveSeasonId ?? null}
-                onValueChange={(next) => {
-                  setSeasonId(next);
-                  // Reset to the newly selected season's first week rather
-                  // than carrying over a week id from a different season.
-                  setWeekId(undefined);
-                }}
-                options={(seasons.data?.seasons ?? []).map((season) => ({
+                value={selectedSeason?.id ?? null}
+                // Drops the week: carrying one over from a different season
+                // would select a week this season doesn't have.
+                onValueChange={onSeasonChange}
+                options={all.map((season) => ({
                   value: season.id,
                   label: seasonLabel(season),
                 }))}
@@ -83,7 +98,7 @@ export function GamesBrowser() {
                 id="games-browser-week"
                 label="Week"
                 value={effectiveWeekId ?? null}
-                onValueChange={setWeekId}
+                onValueChange={onWeekChange}
                 options={(selectedSeason?.weeks ?? []).map((week) => ({
                   value: week.id,
                   label: week.label,

--- a/apps/web/src/components/admin/games-browser.tsx
+++ b/apps/web/src/components/admin/games-browser.tsx
@@ -1,0 +1,232 @@
+import { useState } from "react";
+import { ADMIN_ODDS_SNAPSHOT_LIMIT, SPORT, type AdminGame } from "@picksleagues/schemas";
+import { useAdminGameOdds, useAdminGames, useAdminSeasons } from "@/api/admin";
+import { formatDateTime } from "@/lib/format";
+import { gameStatusLabel } from "@/lib/game";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { LabeledSelect } from "@/components/labeled-select";
+import { AdminQueryState } from "@/components/admin/query-state";
+
+// `LabeledSelect` renders one label string for both the closed trigger and
+// the open list — a single source keeps a selected provisional season
+// readable as provisional even once the list closes, which is the exact
+// thing this browser exists to surface.
+function seasonLabel(season: { year: number; provisional: boolean }) {
+  return `${season.year}${season.provisional ? " (provisional)" : ""}`;
+}
+
+// Empty (not a placeholder dash) when unscored: this renders after the status
+// word, and "Scheduled –" reads as a truncated line rather than "no score yet".
+function scoreText(away: number | null, home: number | null) {
+  return away === null || home === null ? "" : ` ${away}–${home}`;
+}
+
+function isOverridden(game: AdminGame) {
+  return (
+    game.overrideKickoffAt !== null ||
+    game.overrideStatus !== null ||
+    game.overrideHomeScore !== null ||
+    game.overrideAwayScore !== null ||
+    game.overrideSpread !== null
+  );
+}
+
+export function GamesBrowser() {
+  const seasons = useAdminSeasons(SPORT.NFL);
+  // `undefined` means "no explicit choice yet" — derived below to the newest
+  // season / its earliest week (seasons arrive newest-first, weeks
+  // chronological) so the browser opens on the current week without an
+  // effect-driven setState render cascade.
+  const [seasonId, setSeasonId] = useState<string | undefined>();
+  const [weekId, setWeekId] = useState<string | undefined>();
+
+  const effectiveSeasonId = seasonId ?? seasons.data?.seasons[0]?.id;
+  const selectedSeason = seasons.data?.seasons.find((season) => season.id === effectiveSeasonId);
+  const effectiveWeekId = weekId ?? selectedSeason?.weeks[0]?.id;
+  const games = useAdminGames(effectiveWeekId);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Games</CardTitle>
+        <CardDescription>
+          Provider, override, and resolved values for a week&apos;s games.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <AdminQueryState
+          isPending={seasons.isPending}
+          isError={seasons.isError}
+          onRetry={() => seasons.refetch()}
+          errorMessage="Couldn't load seasons."
+          isEmpty={seasons.data?.seasons.length === 0}
+          emptyMessage="No seasons synced yet."
+        >
+          <div className="flex flex-col gap-4">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <LabeledSelect
+                id="games-browser-season"
+                label="Season"
+                value={effectiveSeasonId ?? null}
+                onValueChange={(next) => {
+                  setSeasonId(next);
+                  // Reset to the newly selected season's first week rather
+                  // than carrying over a week id from a different season.
+                  setWeekId(undefined);
+                }}
+                options={(seasons.data?.seasons ?? []).map((season) => ({
+                  value: season.id,
+                  label: seasonLabel(season),
+                }))}
+              />
+              <LabeledSelect
+                id="games-browser-week"
+                label="Week"
+                value={effectiveWeekId ?? null}
+                onValueChange={setWeekId}
+                options={(selectedSeason?.weeks ?? []).map((week) => ({
+                  value: week.id,
+                  label: week.label,
+                }))}
+              />
+            </div>
+
+            {/* A season with no weeks leaves the games query skipped, which
+                reports `isPending` forever — treat "nothing to ask for" as an
+                empty state rather than a load that never resolves. */}
+            <AdminQueryState
+              isPending={Boolean(effectiveWeekId) && games.isPending}
+              isError={games.isError}
+              onRetry={() => games.refetch()}
+              errorMessage="Couldn't load games."
+              isEmpty={!effectiveWeekId || games.data?.games.length === 0}
+              emptyMessage={
+                effectiveWeekId
+                  ? "No games synced for this week."
+                  : "No weeks synced for this season."
+              }
+            >
+              <ul className="flex flex-col gap-3">
+                {games.data?.games.map((game) => (
+                  <GameRow key={game.id} game={game} />
+                ))}
+              </ul>
+            </AdminQueryState>
+          </div>
+        </AdminQueryState>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ResolvedField({
+  label,
+  resolved,
+  provider,
+  showProvider,
+}: {
+  label: string;
+  resolved: string;
+  provider: string;
+  showProvider: boolean;
+}) {
+  return (
+    <span>
+      {label} {resolved}
+      {showProvider && <span className="text-muted-foreground"> · provider: {provider}</span>}
+    </span>
+  );
+}
+
+function GameRow({ game }: { game: AdminGame }) {
+  const overridden = isOverridden(game);
+  const [oddsOpen, setOddsOpen] = useState(false);
+  const odds = useAdminGameOdds(game.id, oddsOpen);
+
+  return (
+    <li className="flex flex-col gap-2 rounded-lg border border-border p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p
+          className="text-sm font-medium text-foreground"
+          title={`${game.awayTeam.name} @ ${game.homeTeam.name}`}
+        >
+          {game.awayTeam.abbreviation} @ {game.homeTeam.abbreviation}
+        </p>
+        {overridden && (
+          <span className="rounded bg-destructive/10 px-1.5 py-0.5 text-xs font-medium text-destructive">
+            Overridden
+          </span>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1 text-xs text-foreground">
+        <ResolvedField
+          label="Kickoff"
+          resolved={formatDateTime(game.effectiveKickoffAt)}
+          provider={formatDateTime(game.kickoffAt)}
+          showProvider={game.overrideKickoffAt !== null}
+        />
+        <ResolvedField
+          label="Status"
+          resolved={`${gameStatusLabel(game.effectiveStatus)}${scoreText(
+            game.effectiveAwayScore,
+            game.effectiveHomeScore,
+          )}`}
+          provider={`${gameStatusLabel(game.status)}${scoreText(game.awayScore, game.homeScore)}`}
+          showProvider={
+            game.overrideStatus !== null ||
+            game.overrideHomeScore !== null ||
+            game.overrideAwayScore !== null
+          }
+        />
+        <ResolvedField
+          label="Spread"
+          resolved={game.effectiveSpread === null ? "no line" : String(game.effectiveSpread)}
+          provider={game.latestSpread === null ? "no line" : String(game.latestSpread)}
+          showProvider={game.overrideSpread !== null}
+        />
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        Spread captured{" "}
+        {game.latestSpreadCapturedAt ? formatDateTime(game.latestSpreadCapturedAt) : "never"} ·
+        provider game id {game.providerGameId}
+      </p>
+
+      <details open={oddsOpen} onToggle={(event) => setOddsOpen(event.currentTarget.open)}>
+        <summary className="cursor-pointer text-xs text-muted-foreground select-none">
+          Odds history
+        </summary>
+        {oddsOpen && (
+          <div className="mt-2">
+            <AdminQueryState
+              isPending={odds.isPending}
+              isError={odds.isError}
+              onRetry={() => odds.refetch()}
+              errorMessage="Couldn't load odds history."
+              isEmpty={odds.data?.snapshots.length === 0}
+              emptyMessage="No odds captured yet."
+            >
+              <ul className="flex flex-col gap-1">
+                {odds.data?.snapshots.map((snapshot) => (
+                  <li
+                    key={snapshot.id}
+                    className="flex justify-between gap-2 text-xs text-muted-foreground"
+                  >
+                    <span>{snapshot.spread}</span>
+                    <span>{formatDateTime(snapshot.capturedAt)}</span>
+                  </li>
+                ))}
+              </ul>
+              {odds.data?.snapshots.length === ADMIN_ODDS_SNAPSHOT_LIMIT && (
+                <p className="mt-1 text-xs text-muted-foreground/70">
+                  Only the most recent {ADMIN_ODDS_SNAPSHOT_LIMIT} snapshots are shown.
+                </p>
+              )}
+            </AdminQueryState>
+          </div>
+        )}
+      </details>
+    </li>
+  );
+}

--- a/apps/web/src/components/admin/query-state.tsx
+++ b/apps/web/src/components/admin/query-state.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+
+// Shared loading/error/empty triad for the admin page's read-only browsers
+// (rule of three: the teams, seasons, and games browsers all needed this) —
+// mirrors the discovery page's idiom (centered py-8, outline Retry button)
+// without restating it per browser.
+export function AdminQueryState({
+  isPending,
+  isError,
+  onRetry,
+  errorMessage,
+  isEmpty,
+  emptyMessage,
+  children,
+}: {
+  isPending: boolean;
+  isError: boolean;
+  onRetry: () => void;
+  errorMessage: string;
+  isEmpty?: boolean;
+  emptyMessage?: string;
+  children: ReactNode;
+}) {
+  if (isPending) {
+    return <p className="py-8 text-center text-sm text-muted-foreground">Loading…</p>;
+  }
+
+  if (isError) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-8">
+        <p className="text-sm text-muted-foreground">{errorMessage}</p>
+        <Button variant="outline" onClick={onRetry}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  if (isEmpty) {
+    return <p className="py-8 text-center text-sm text-muted-foreground">{emptyMessage}</p>;
+  }
+
+  return <>{children}</>;
+}

--- a/apps/web/src/components/admin/seasons-browser.tsx
+++ b/apps/web/src/components/admin/seasons-browser.tsx
@@ -1,0 +1,83 @@
+import { SPORT } from "@picksleagues/schemas";
+import { useAdminSeasons } from "@/api/admin";
+import { formatDateTime } from "@/lib/format";
+import { weekTypeLabel } from "@/lib/game";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { AdminQueryState } from "@/components/admin/query-state";
+
+export function SeasonsBrowser() {
+  const seasons = useAdminSeasons(SPORT.NFL);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Seasons &amp; weeks</CardTitle>
+        <CardDescription>Synced NFL seasons and their weeks.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <AdminQueryState
+          isPending={seasons.isPending}
+          isError={seasons.isError}
+          onRetry={() => seasons.refetch()}
+          errorMessage="Couldn't load seasons."
+          isEmpty={seasons.data?.seasons.length === 0}
+          emptyMessage="No seasons synced yet."
+        >
+          <ul className="flex flex-col gap-4">
+            {seasons.data?.seasons.map((season) => (
+              <li
+                key={season.id}
+                className="flex flex-col gap-2 rounded-lg border border-border p-3"
+              >
+                <div className="flex items-center gap-2">
+                  <p className="text-sm font-medium text-foreground">{season.year}</p>
+                  {season.provisional && (
+                    <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+                      provisional
+                    </span>
+                  )}
+                </div>
+                {/* A provisional season exists before its structure is
+                    ingested (ADR-0009), so an empty week list is expected
+                    state, not an error. */}
+                {season.weeks.length === 0 && (
+                  <p className="text-xs text-muted-foreground">No weeks synced yet.</p>
+                )}
+                <ul className="flex flex-col gap-1.5">
+                  {season.weeks.map((week) => (
+                    <li
+                      key={week.id}
+                      className="flex flex-col gap-0.5 text-xs sm:flex-row sm:items-center sm:justify-between"
+                    >
+                      <span className="text-foreground">
+                        {week.label}
+                        <span className="text-muted-foreground">
+                          {" "}
+                          · {weekTypeLabel(week.weekType)}
+                        </span>
+                      </span>
+                      <span className="text-muted-foreground">
+                        {formatDateTime(week.startsAt)} – {formatDateTime(week.endsAt)} ·{" "}
+                        {/* A synced week with zero games is the sync-failure signal this
+                            browser exists for (schema comment on AdminWeek.gameCount). */}
+                        <span
+                          className={
+                            week.gameCount === 0
+                              ? "font-medium text-destructive"
+                              : "text-muted-foreground"
+                          }
+                        >
+                          {week.gameCount} game{week.gameCount === 1 ? "" : "s"}
+                        </span>
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            ))}
+          </ul>
+        </AdminQueryState>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/admin/seasons-browser.tsx
+++ b/apps/web/src/components/admin/seasons-browser.tsx
@@ -1,4 +1,5 @@
-import { SPORT } from "@picksleagues/schemas";
+import { Link } from "@tanstack/react-router";
+import { SPORT, type AdminSeason } from "@picksleagues/schemas";
 import { useAdminSeasons } from "@/api/admin";
 import { formatDateTime } from "@/lib/format";
 import { weekTypeLabel } from "@/lib/game";
@@ -12,7 +13,10 @@ export function SeasonsBrowser() {
     <Card>
       <CardHeader>
         <CardTitle>Seasons &amp; weeks</CardTitle>
-        <CardDescription>Synced NFL seasons and their weeks.</CardDescription>
+        <CardDescription>
+          Synced NFL seasons and their weeks. A week with no games is a sync that didn&apos;t finish
+          — open it to see the slate.
+        </CardDescription>
       </CardHeader>
       <CardContent>
         <AdminQueryState
@@ -24,60 +28,70 @@ export function SeasonsBrowser() {
           emptyMessage="No seasons synced yet."
         >
           <ul className="flex flex-col gap-4">
-            {seasons.data?.seasons.map((season) => (
-              <li
-                key={season.id}
-                className="flex flex-col gap-2 rounded-lg border border-border p-3"
-              >
-                <div className="flex items-center gap-2">
-                  <p className="text-sm font-medium text-foreground">{season.year}</p>
-                  {season.provisional && (
-                    <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
-                      provisional
-                    </span>
-                  )}
-                </div>
-                {/* A provisional season exists before its structure is
-                    ingested (ADR-0009), so an empty week list is expected
-                    state, not an error. */}
-                {season.weeks.length === 0 && (
-                  <p className="text-xs text-muted-foreground">No weeks synced yet.</p>
-                )}
-                <ul className="flex flex-col gap-1.5">
-                  {season.weeks.map((week) => (
-                    <li
-                      key={week.id}
-                      className="flex flex-col gap-0.5 text-xs sm:flex-row sm:items-center sm:justify-between"
-                    >
-                      <span className="text-foreground">
-                        {week.label}
-                        <span className="text-muted-foreground">
-                          {" "}
-                          · {weekTypeLabel(week.weekType)}
-                        </span>
-                      </span>
-                      <span className="text-muted-foreground">
-                        {formatDateTime(week.startsAt)} – {formatDateTime(week.endsAt)} ·{" "}
-                        {/* A synced week with zero games is the sync-failure signal this
-                            browser exists for (schema comment on AdminWeek.gameCount). */}
-                        <span
-                          className={
-                            week.gameCount === 0
-                              ? "font-medium text-destructive"
-                              : "text-muted-foreground"
-                          }
-                        >
-                          {week.gameCount} game{week.gameCount === 1 ? "" : "s"}
-                        </span>
-                      </span>
-                    </li>
-                  ))}
-                </ul>
+            {seasons.data?.seasons.map((season, index) => (
+              <li key={season.id}>
+                {/* Every season carries ~22 weeks, so only the newest opens by
+                    default — past seasons stay one click away rather than
+                    burying the current one under a season of scroll. */}
+                <SeasonSection season={season} defaultOpen={index === 0} />
               </li>
             ))}
           </ul>
         </AdminQueryState>
       </CardContent>
     </Card>
+  );
+}
+
+function SeasonSection({ season, defaultOpen }: { season: AdminSeason; defaultOpen: boolean }) {
+  return (
+    <details open={defaultOpen} className="rounded-lg border border-border p-3">
+      <summary className="flex cursor-pointer items-center gap-2 select-none">
+        <span className="text-sm font-medium text-foreground">{season.year}</span>
+        {season.provisional && (
+          <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+            provisional
+          </span>
+        )}
+        <span className="text-xs text-muted-foreground">
+          {season.weeks.length} week{season.weeks.length === 1 ? "" : "s"}
+        </span>
+      </summary>
+
+      {/* A provisional season exists before its structure is ingested
+          (ADR-0009), so an empty week list is expected state, not an error. */}
+      {season.weeks.length === 0 && (
+        <p className="mt-2 text-xs text-muted-foreground">No weeks synced yet.</p>
+      )}
+
+      <ul className="mt-2 flex flex-col gap-1.5">
+        {season.weeks.map((week) => (
+          <li key={week.id}>
+            <Link
+              to="/admin/games"
+              search={{ weekId: week.id }}
+              className="flex flex-col gap-0.5 rounded-md px-1 py-0.5 text-xs outline-none hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/50 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <span className="text-foreground">
+                {week.label}
+                <span className="text-muted-foreground"> · {weekTypeLabel(week.weekType)}</span>
+              </span>
+              <span className="text-muted-foreground">
+                {formatDateTime(week.startsAt)} – {formatDateTime(week.endsAt)} ·{" "}
+                {/* A synced week with zero games is the sync-failure signal this
+                    browser exists for (schema comment on AdminWeek.gameCount). */}
+                <span
+                  className={
+                    week.gameCount === 0 ? "font-medium text-destructive" : "text-muted-foreground"
+                  }
+                >
+                  {week.gameCount} game{week.gameCount === 1 ? "" : "s"}
+                </span>
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </details>
   );
 }

--- a/apps/web/src/components/admin/sync-jobs-card.tsx
+++ b/apps/web/src/components/admin/sync-jobs-card.tsx
@@ -1,0 +1,71 @@
+import { NFL_SYNC_JOB, type NflSyncJob } from "@picksleagues/schemas";
+import { useRunNflSyncJob } from "@/api/admin";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+// Row copy for the three manual sync triggers — kept here rather than in the
+// api module since it's page display copy, not part of the mutation's shape.
+const NFL_SYNC_JOB_ROWS: { job: NflSyncJob; label: string; description: string }[] = [
+  {
+    job: NFL_SYNC_JOB.SYNC_SCHEDULE,
+    label: "Sync schedule",
+    description: "Weeks, games, and kickoff times.",
+  },
+  {
+    job: NFL_SYNC_JOB.SYNC_ODDS,
+    label: "Sync odds",
+    description: "Spread snapshots for games that haven't started.",
+  },
+  {
+    job: NFL_SYNC_JOB.SYNC_SCORES,
+    label: "Sync scores",
+    description: "Live and final scores.",
+  },
+];
+
+export function SyncJobsCard() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>NFL data sync</CardTitle>
+        <CardDescription>
+          Manually trigger the same sync jobs the cron scheduler runs.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        {NFL_SYNC_JOB_ROWS.map((row) => (
+          <SyncJobRow key={row.job} job={row.job} label={row.label} description={row.description} />
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+function SyncJobRow({
+  job,
+  label,
+  description,
+}: {
+  job: NflSyncJob;
+  label: string;
+  description: string;
+}) {
+  const runJob = useRunNflSyncJob();
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-border p-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-0.5">
+        <p className="text-sm font-medium text-foreground">{label}</p>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={runJob.isPending && runJob.variables === job}
+        onClick={() => runJob.mutate(job)}
+      >
+        Run
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/teams-browser.tsx
+++ b/apps/web/src/components/admin/teams-browser.tsx
@@ -1,0 +1,77 @@
+import { SPORT } from "@picksleagues/schemas";
+import { useAdminTeams } from "@/api/admin";
+import { formatDateTime } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { AdminQueryState } from "@/components/admin/query-state";
+
+// NCAAMB teams arrive with the March Madness epic; only NFL data exists
+// today (ADM-4 spec) — no sport picker until there's a second sport to pick.
+export function TeamsBrowser() {
+  const teams = useAdminTeams(SPORT.NFL);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Teams</CardTitle>
+        <CardDescription>
+          {teams.data ? `${teams.data.teams.length} synced` : "Synced NFL teams"}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <AdminQueryState
+          isPending={teams.isPending}
+          isError={teams.isError}
+          onRetry={() => teams.refetch()}
+          errorMessage="Couldn't load teams."
+          isEmpty={teams.data?.teams.length === 0}
+          emptyMessage="No teams synced yet."
+        >
+          <ul className="flex flex-col gap-2">
+            {teams.data?.teams.map((team) => (
+              <li
+                key={team.id}
+                className="flex items-center gap-3 rounded-lg border border-border p-3"
+              >
+                {/* Root's `.dark` class (index.css `@custom-variant dark`) drives
+                    which logo is visible. Only theme-toggle a URL when the other
+                    theme's variant also exists — a team with just one logo shows
+                    it in both themes rather than going blank; a TBD/bootstrap
+                    team with neither falls back to the placeholder. */}
+                {team.logoLightUrl && (
+                  <img
+                    src={team.logoLightUrl}
+                    alt=""
+                    className={cn("size-8 shrink-0", team.logoDarkUrl && "dark:hidden")}
+                  />
+                )}
+                {team.logoDarkUrl && (
+                  <img
+                    src={team.logoDarkUrl}
+                    alt=""
+                    className={cn("size-8 shrink-0", team.logoLightUrl && "hidden dark:block")}
+                  />
+                )}
+                {!team.logoLightUrl && !team.logoDarkUrl && (
+                  <div className="size-8 shrink-0 rounded-full bg-muted" />
+                )}
+                <div className="flex min-w-0 flex-1 flex-col">
+                  <p className="text-sm font-medium text-foreground">
+                    {team.abbreviation} — {team.name}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {team.location ?? "Location unknown"}
+                  </p>
+                </div>
+                <div className="flex shrink-0 flex-col items-end text-xs text-muted-foreground">
+                  <p>{team.providerTeamId ?? "not provider-linked"}</p>
+                  <p>Updated {formatDateTime(team.updatedAt)}</p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </AdminQueryState>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/labeled-select.tsx
+++ b/apps/web/src/components/labeled-select.tsx
@@ -1,0 +1,59 @@
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+// Generic labeled select over `{ value, label }[]` — shared by the league
+// settings fieldsets' week/push-tie pickers and the admin games browser's
+// season/week pickers, so a labeled Select is written once.
+// Generic over the option's literal union (same idiom as RadioField) so a
+// caller whose values are a const-object union keeps that type through the
+// callback instead of casting a bare string back to it.
+export function LabeledSelect<Value extends string>({
+  id,
+  label,
+  value,
+  onValueChange,
+  options,
+}: {
+  id: string;
+  label: string;
+  // `null`, never `undefined` — Base UI's Select treats a value transitioning
+  // to `undefined` as switching from controlled to uncontrolled (console
+  // warning); `null` is its documented "no selection" value.
+  value: Value | null;
+  onValueChange: (value: Value) => void;
+  options: { value: Value; label: string }[];
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label htmlFor={id}>{label}</Label>
+      {/* `items` is Base UI's value→label map for the closed trigger — without
+          it, Select.Value renders the raw wire value ("regular:1") instead of
+          the option label ("Week 1"). Since options are already `{value, label}`,
+          Base UI reads the label straight off them, no `itemToStringLabel` needed. */}
+      <Select
+        items={options}
+        value={value}
+        onValueChange={(next) => {
+          if (next) onValueChange(next as Value);
+        }}
+      >
+        <SelectTrigger id={id} className="w-full">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/apps/web/src/components/league-settings-fields.tsx
+++ b/apps/web/src/components/league-settings-fields.tsx
@@ -14,13 +14,7 @@ import {
 } from "@picksleagues/schemas";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { LabeledSelect } from "@/components/labeled-select";
 import { NumberField } from "@/components/number-field";
 
 // Per-mode league settings fieldsets, shared by the create-league form
@@ -154,50 +148,6 @@ export function RadioField<Value extends string>({
   );
 }
 
-// Shared week-select wiring for start/end week pairs across Pick'em and
-// Elimination — options carry the encodeWeek/decodeWeek round-trip value.
-export function WeekSelect({
-  id,
-  label,
-  value,
-  onValueChange,
-  options,
-}: {
-  id: string;
-  label: string;
-  value: string;
-  onValueChange: (value: string) => void;
-  options: { value: string; label: string }[];
-}) {
-  return (
-    <div className="flex flex-col gap-1.5">
-      <Label htmlFor={id}>{label}</Label>
-      {/* `items` is Base UI's value→label map for the closed trigger — without
-          it, Select.Value renders the raw wire value ("regular:1") instead of
-          the option label ("Week 1"). Since options are already `{value, label}`,
-          Base UI reads the label straight off them, no `itemToStringLabel` needed. */}
-      <Select
-        items={options}
-        value={value}
-        onValueChange={(next) => {
-          if (next) onValueChange(next);
-        }}
-      >
-        <SelectTrigger id={id} className="w-full">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {options.map((option) => (
-            <SelectItem key={option.value} value={option.value}>
-              {option.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
-  );
-}
-
 export function PickemSettingsFields({
   startWeek,
   onStartWeekChange,
@@ -225,14 +175,14 @@ export function PickemSettingsFields({
     <div className="flex flex-col gap-4">
       <h2 className="text-sm font-semibold text-foreground">Pick&apos;em settings</h2>
       <div className="grid grid-cols-2 gap-3">
-        <WeekSelect
+        <LabeledSelect
           id="pickem-start-week"
           label="Start week"
           value={startWeek}
           onValueChange={onStartWeekChange}
           options={PICKEM_WEEK_OPTIONS}
         />
-        <WeekSelect
+        <LabeledSelect
           id="pickem-end-week"
           label="End week"
           value={endWeek}
@@ -255,27 +205,13 @@ export function PickemSettingsFields({
         value={picksPerWeek}
         onValueChange={onPicksPerWeekChange}
       />
-      <div className="flex flex-col gap-1.5">
-        <Label htmlFor="pickem-push-tie">Push / tie value</Label>
-        <Select
-          items={PICKEM_PUSH_TIE_OPTIONS}
-          value={pushTie}
-          onValueChange={(next) => {
-            if (next) onPushTieChange(next);
-          }}
-        >
-          <SelectTrigger id="pickem-push-tie" className="w-full">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {PICKEM_PUSH_TIE_OPTIONS.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
+      <LabeledSelect
+        id="pickem-push-tie"
+        label="Push / tie value"
+        value={pushTie}
+        onValueChange={onPushTieChange}
+        options={PICKEM_PUSH_TIE_OPTIONS}
+      />
     </div>
   );
 }
@@ -303,14 +239,14 @@ export function EliminationSettingsFields({
     <div className="flex flex-col gap-4">
       <h2 className="text-sm font-semibold text-foreground">Elimination settings</h2>
       <div className="grid grid-cols-2 gap-3">
-        <WeekSelect
+        <LabeledSelect
           id="elimination-start-week"
           label="Start week"
           value={startWeek}
           onValueChange={onStartWeekChange}
           options={REGULAR_WEEK_OPTIONS}
         />
-        <WeekSelect
+        <LabeledSelect
           id="elimination-end-week"
           label="End week"
           value={endWeek}

--- a/apps/web/src/components/league/invite-panel.tsx
+++ b/apps/web/src/components/league/invite-panel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { INVITE_STATUS, type CreateInviteRequest, type Invite } from "@picksleagues/schemas";
 import { useCreateInvite, useLeagueInvites, useRevokeInvite } from "@/api/invites";
+import { formatDateTime } from "@/lib/format";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -85,7 +86,7 @@ function InviteRow({
         </div>
         <div className="flex gap-1">
           <dt>Expires:</dt>
-          <dd>{invite.expiresAt ? new Date(invite.expiresAt).toLocaleString() : "Never"}</dd>
+          <dd>{invite.expiresAt ? formatDateTime(invite.expiresAt) : "Never"}</dd>
         </div>
       </dl>
       <div className="flex gap-2">

--- a/apps/web/src/components/league/league-header.tsx
+++ b/apps/web/src/components/league/league-header.tsx
@@ -1,4 +1,5 @@
 import type { LeagueResponse } from "@picksleagues/schemas";
+import { formatDateTime } from "@/lib/format";
 import { leagueModeLabel } from "@/lib/league";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
@@ -35,11 +36,7 @@ export function LeagueHeader({
         <p>
           {league.members.length} member{league.members.length === 1 ? "" : "s"}
         </p>
-        <p>
-          {league.startsAt
-            ? `Starts ${new Date(league.startsAt).toLocaleString()}`
-            : "Start date TBD"}
-        </p>
+        <p>{league.startsAt ? `Starts ${formatDateTime(league.startsAt)}` : "Start date TBD"}</p>
       </CardContent>
     </Card>
   );

--- a/apps/web/src/components/tab-nav.tsx
+++ b/apps/web/src/components/tab-nav.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+// Shared underline tab-bar chrome for layout routes whose children are
+// sections of one thing (a league, the admin surface). Tabs are real routes,
+// not local state, so each section is deep-linkable and survives a refresh —
+// callers render `<Link>`s with these props and their own `to`/`params`.
+const tabLinkClassName =
+  "border-b-2 border-transparent px-1 pb-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring/50";
+
+export const tabLinkProps = {
+  className: tabLinkClassName,
+  inactiveProps: { className: "text-muted-foreground" },
+  activeProps: {
+    className: cn(tabLinkClassName, "border-foreground font-medium text-foreground"),
+    "aria-current": "page" as const,
+  },
+};
+
+export function TabNav({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <nav
+      aria-label={label}
+      // Scrolls rather than wraps: the admin bar is five tabs wide at phone
+      // width, and a wrapped second row reads as a separate control.
+      className="flex gap-4 overflow-x-auto border-b border-border text-sm"
+    >
+      {children}
+    </nav>
+  );
+}

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -1,0 +1,6 @@
+// One home for "render an ISO timestamp in the viewer's local timezone"
+// (engineering rules: kickoff times/deadlines always render local, never a
+// fixed zone) — every kickoff/deadline display in the SPA goes through this.
+export function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleString();
+}

--- a/apps/web/src/lib/game.ts
+++ b/apps/web/src/lib/game.ts
@@ -1,0 +1,27 @@
+import { GAME_STATUS, WEEK_TYPE, type GameStatus, type WeekType } from "@picksleagues/schemas";
+
+// One home for the sports-data display labels (engineering rule on derived
+// display values), alongside lib/league.ts's mode/role maps. The admin
+// browsers are the first consumer; the pick and standings surfaces render the
+// same statuses.
+const GAME_STATUS_LABELS: Record<GameStatus, string> = {
+  [GAME_STATUS.SCHEDULED]: "Scheduled",
+  [GAME_STATUS.IN_PROGRESS]: "In progress",
+  [GAME_STATUS.FINAL]: "Final",
+  [GAME_STATUS.POSTPONED]: "Postponed",
+  [GAME_STATUS.CANCELLED]: "Cancelled",
+  [GAME_STATUS.MOVED]: "Moved",
+};
+
+export function gameStatusLabel(status: GameStatus): string {
+  return GAME_STATUS_LABELS[status];
+}
+
+const WEEK_TYPE_LABELS: Record<WeekType, string> = {
+  [WEEK_TYPE.REGULAR]: "Regular season",
+  [WEEK_TYPE.POSTSEASON]: "Postseason",
+};
+
+export function weekTypeLabel(weekType: WeekType): string {
+  return WEEK_TYPE_LABELS[weekType];
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -13,10 +13,14 @@ import { Route as AuthedRouteImport } from './routes/_authed'
 import { Route as ClaimUsernameRouteImport } from './routes/claim-username'
 import { Route as SignInRouteImport } from './routes/sign-in'
 import { Route as AuthedIndexRouteImport } from './routes/_authed/index'
-import { Route as AuthedAdminRouteImport } from './routes/_authed/admin'
+import { Route as AuthedAdminRouteRouteImport } from './routes/_authed/admin/route'
 import { Route as AuthedDiscoveryRouteImport } from './routes/_authed/discovery'
 import { Route as AuthedProfileRouteImport } from './routes/_authed/profile'
 import { Route as JoinCodeRouteImport } from './routes/join.$code'
+import { Route as AuthedAdminIndexRouteImport } from './routes/_authed/admin/index'
+import { Route as AuthedAdminGamesRouteImport } from './routes/_authed/admin/games'
+import { Route as AuthedAdminSeasonsRouteImport } from './routes/_authed/admin/seasons'
+import { Route as AuthedAdminTeamsRouteImport } from './routes/_authed/admin/teams'
 import { Route as AuthedLeaguesLeagueIdRouteRouteImport } from './routes/_authed/leagues/$leagueId/route'
 import { Route as AuthedLeaguesNewRouteImport } from './routes/_authed/leagues/new'
 import { Route as AuthedLeaguesLeagueIdIndexRouteImport } from './routes/_authed/leagues/$leagueId/index'
@@ -42,7 +46,7 @@ const AuthedIndexRoute = AuthedIndexRouteImport.update({
   path: '/',
   getParentRoute: () => AuthedRoute,
 } as any)
-const AuthedAdminRoute = AuthedAdminRouteImport.update({
+const AuthedAdminRouteRoute = AuthedAdminRouteRouteImport.update({
   id: '/admin',
   path: '/admin',
   getParentRoute: () => AuthedRoute,
@@ -61,6 +65,26 @@ const JoinCodeRoute = JoinCodeRouteImport.update({
   id: '/join/$code',
   path: '/join/$code',
   getParentRoute: () => rootRouteImport,
+} as any)
+const AuthedAdminIndexRoute = AuthedAdminIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AuthedAdminRouteRoute,
+} as any)
+const AuthedAdminGamesRoute = AuthedAdminGamesRouteImport.update({
+  id: '/games',
+  path: '/games',
+  getParentRoute: () => AuthedAdminRouteRoute,
+} as any)
+const AuthedAdminSeasonsRoute = AuthedAdminSeasonsRouteImport.update({
+  id: '/seasons',
+  path: '/seasons',
+  getParentRoute: () => AuthedAdminRouteRoute,
+} as any)
+const AuthedAdminTeamsRoute = AuthedAdminTeamsRouteImport.update({
+  id: '/teams',
+  path: '/teams',
+  getParentRoute: () => AuthedAdminRouteRoute,
 } as any)
 const AuthedLeaguesLeagueIdRouteRoute =
   AuthedLeaguesLeagueIdRouteRouteImport.update({
@@ -96,12 +120,16 @@ export interface FileRoutesByFullPath {
   '/': typeof AuthedIndexRoute
   '/claim-username': typeof ClaimUsernameRoute
   '/sign-in': typeof SignInRoute
-  '/admin': typeof AuthedAdminRoute
+  '/admin': typeof AuthedAdminRouteRouteWithChildren
   '/discovery': typeof AuthedDiscoveryRoute
   '/profile': typeof AuthedProfileRoute
   '/join/$code': typeof JoinCodeRoute
   '/leagues/$leagueId': typeof AuthedLeaguesLeagueIdRouteRouteWithChildren
+  '/admin/games': typeof AuthedAdminGamesRoute
+  '/admin/seasons': typeof AuthedAdminSeasonsRoute
+  '/admin/teams': typeof AuthedAdminTeamsRoute
   '/leagues/new': typeof AuthedLeaguesNewRoute
+  '/admin/': typeof AuthedAdminIndexRoute
   '/leagues/$leagueId/members': typeof AuthedLeaguesLeagueIdMembersRoute
   '/leagues/$leagueId/settings': typeof AuthedLeaguesLeagueIdSettingsRoute
   '/leagues/$leagueId/': typeof AuthedLeaguesLeagueIdIndexRoute
@@ -109,12 +137,15 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/claim-username': typeof ClaimUsernameRoute
   '/sign-in': typeof SignInRoute
-  '/admin': typeof AuthedAdminRoute
   '/discovery': typeof AuthedDiscoveryRoute
   '/profile': typeof AuthedProfileRoute
   '/join/$code': typeof JoinCodeRoute
   '/': typeof AuthedIndexRoute
+  '/admin/games': typeof AuthedAdminGamesRoute
+  '/admin/seasons': typeof AuthedAdminSeasonsRoute
+  '/admin/teams': typeof AuthedAdminTeamsRoute
   '/leagues/new': typeof AuthedLeaguesNewRoute
+  '/admin': typeof AuthedAdminIndexRoute
   '/leagues/$leagueId/members': typeof AuthedLeaguesLeagueIdMembersRoute
   '/leagues/$leagueId/settings': typeof AuthedLeaguesLeagueIdSettingsRoute
   '/leagues/$leagueId': typeof AuthedLeaguesLeagueIdIndexRoute
@@ -124,13 +155,17 @@ export interface FileRoutesById {
   '/_authed': typeof AuthedRouteWithChildren
   '/claim-username': typeof ClaimUsernameRoute
   '/sign-in': typeof SignInRoute
-  '/_authed/admin': typeof AuthedAdminRoute
+  '/_authed/admin': typeof AuthedAdminRouteRouteWithChildren
   '/_authed/discovery': typeof AuthedDiscoveryRoute
   '/_authed/profile': typeof AuthedProfileRoute
   '/join/$code': typeof JoinCodeRoute
   '/_authed/': typeof AuthedIndexRoute
   '/_authed/leagues/$leagueId': typeof AuthedLeaguesLeagueIdRouteRouteWithChildren
+  '/_authed/admin/games': typeof AuthedAdminGamesRoute
+  '/_authed/admin/seasons': typeof AuthedAdminSeasonsRoute
+  '/_authed/admin/teams': typeof AuthedAdminTeamsRoute
   '/_authed/leagues/new': typeof AuthedLeaguesNewRoute
+  '/_authed/admin/': typeof AuthedAdminIndexRoute
   '/_authed/leagues/$leagueId/members': typeof AuthedLeaguesLeagueIdMembersRoute
   '/_authed/leagues/$leagueId/settings': typeof AuthedLeaguesLeagueIdSettingsRoute
   '/_authed/leagues/$leagueId/': typeof AuthedLeaguesLeagueIdIndexRoute
@@ -146,7 +181,11 @@ export interface FileRouteTypes {
     | '/profile'
     | '/join/$code'
     | '/leagues/$leagueId'
+    | '/admin/games'
+    | '/admin/seasons'
+    | '/admin/teams'
     | '/leagues/new'
+    | '/admin/'
     | '/leagues/$leagueId/members'
     | '/leagues/$leagueId/settings'
     | '/leagues/$leagueId/'
@@ -154,12 +193,15 @@ export interface FileRouteTypes {
   to:
     | '/claim-username'
     | '/sign-in'
-    | '/admin'
     | '/discovery'
     | '/profile'
     | '/join/$code'
     | '/'
+    | '/admin/games'
+    | '/admin/seasons'
+    | '/admin/teams'
     | '/leagues/new'
+    | '/admin'
     | '/leagues/$leagueId/members'
     | '/leagues/$leagueId/settings'
     | '/leagues/$leagueId'
@@ -174,7 +216,11 @@ export interface FileRouteTypes {
     | '/join/$code'
     | '/_authed/'
     | '/_authed/leagues/$leagueId'
+    | '/_authed/admin/games'
+    | '/_authed/admin/seasons'
+    | '/_authed/admin/teams'
     | '/_authed/leagues/new'
+    | '/_authed/admin/'
     | '/_authed/leagues/$leagueId/members'
     | '/_authed/leagues/$leagueId/settings'
     | '/_authed/leagues/$leagueId/'
@@ -221,7 +267,7 @@ declare module '@tanstack/react-router' {
       id: '/_authed/admin'
       path: '/admin'
       fullPath: '/admin'
-      preLoaderRoute: typeof AuthedAdminRouteImport
+      preLoaderRoute: typeof AuthedAdminRouteRouteImport
       parentRoute: typeof AuthedRoute
     }
     '/_authed/discovery': {
@@ -244,6 +290,34 @@ declare module '@tanstack/react-router' {
       fullPath: '/join/$code'
       preLoaderRoute: typeof JoinCodeRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/_authed/admin/': {
+      id: '/_authed/admin/'
+      path: '/'
+      fullPath: '/admin/'
+      preLoaderRoute: typeof AuthedAdminIndexRouteImport
+      parentRoute: typeof AuthedAdminRouteRoute
+    }
+    '/_authed/admin/games': {
+      id: '/_authed/admin/games'
+      path: '/games'
+      fullPath: '/admin/games'
+      preLoaderRoute: typeof AuthedAdminGamesRouteImport
+      parentRoute: typeof AuthedAdminRouteRoute
+    }
+    '/_authed/admin/seasons': {
+      id: '/_authed/admin/seasons'
+      path: '/seasons'
+      fullPath: '/admin/seasons'
+      preLoaderRoute: typeof AuthedAdminSeasonsRouteImport
+      parentRoute: typeof AuthedAdminRouteRoute
+    }
+    '/_authed/admin/teams': {
+      id: '/_authed/admin/teams'
+      path: '/teams'
+      fullPath: '/admin/teams'
+      preLoaderRoute: typeof AuthedAdminTeamsRouteImport
+      parentRoute: typeof AuthedAdminRouteRoute
     }
     '/_authed/leagues/$leagueId': {
       id: '/_authed/leagues/$leagueId'
@@ -283,6 +357,23 @@ declare module '@tanstack/react-router' {
   }
 }
 
+interface AuthedAdminRouteRouteChildren {
+  AuthedAdminGamesRoute: typeof AuthedAdminGamesRoute
+  AuthedAdminSeasonsRoute: typeof AuthedAdminSeasonsRoute
+  AuthedAdminTeamsRoute: typeof AuthedAdminTeamsRoute
+  AuthedAdminIndexRoute: typeof AuthedAdminIndexRoute
+}
+
+const AuthedAdminRouteRouteChildren: AuthedAdminRouteRouteChildren = {
+  AuthedAdminGamesRoute: AuthedAdminGamesRoute,
+  AuthedAdminSeasonsRoute: AuthedAdminSeasonsRoute,
+  AuthedAdminTeamsRoute: AuthedAdminTeamsRoute,
+  AuthedAdminIndexRoute: AuthedAdminIndexRoute,
+}
+
+const AuthedAdminRouteRouteWithChildren =
+  AuthedAdminRouteRoute._addFileChildren(AuthedAdminRouteRouteChildren)
+
 interface AuthedLeaguesLeagueIdRouteRouteChildren {
   AuthedLeaguesLeagueIdMembersRoute: typeof AuthedLeaguesLeagueIdMembersRoute
   AuthedLeaguesLeagueIdSettingsRoute: typeof AuthedLeaguesLeagueIdSettingsRoute
@@ -302,7 +393,7 @@ const AuthedLeaguesLeagueIdRouteRouteWithChildren =
   )
 
 interface AuthedRouteChildren {
-  AuthedAdminRoute: typeof AuthedAdminRoute
+  AuthedAdminRouteRoute: typeof AuthedAdminRouteRouteWithChildren
   AuthedDiscoveryRoute: typeof AuthedDiscoveryRoute
   AuthedProfileRoute: typeof AuthedProfileRoute
   AuthedIndexRoute: typeof AuthedIndexRoute
@@ -311,7 +402,7 @@ interface AuthedRouteChildren {
 }
 
 const AuthedRouteChildren: AuthedRouteChildren = {
-  AuthedAdminRoute: AuthedAdminRoute,
+  AuthedAdminRouteRoute: AuthedAdminRouteRouteWithChildren,
   AuthedDiscoveryRoute: AuthedDiscoveryRoute,
   AuthedProfileRoute: AuthedProfileRoute,
   AuthedIndexRoute: AuthedIndexRoute,

--- a/apps/web/src/routes/_authed/admin.tsx
+++ b/apps/web/src/routes/_authed/admin.tsx
@@ -1,33 +1,14 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { NFL_SYNC_JOB, type NflSyncJob } from "@picksleagues/schemas";
 import { useMe } from "@/api/me";
-import { useRunNflSyncJob } from "@/api/admin";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { SyncJobsCard } from "@/components/admin/sync-jobs-card";
+import { TeamsBrowser } from "@/components/admin/teams-browser";
+import { SeasonsBrowser } from "@/components/admin/seasons-browser";
+import { GamesBrowser } from "@/components/admin/games-browser";
 
 export const Route = createFileRoute("/_authed/admin")({
   component: Admin,
 });
-
-// Row copy for the three manual sync triggers — kept here rather than in the
-// api module since it's page display copy, not part of the mutation's shape.
-const NFL_SYNC_JOB_ROWS: { job: NflSyncJob; label: string; description: string }[] = [
-  {
-    job: NFL_SYNC_JOB.SYNC_SCHEDULE,
-    label: "Sync schedule",
-    description: "Weeks, games, and kickoff times.",
-  },
-  {
-    job: NFL_SYNC_JOB.SYNC_ODDS,
-    label: "Sync odds",
-    description: "Spread snapshots for games that haven't started.",
-  },
-  {
-    job: NFL_SYNC_JOB.SYNC_SCORES,
-    label: "Sync scores",
-    description: "Live and final scores.",
-  },
-];
 
 function Admin() {
   const me = useMe();
@@ -65,53 +46,10 @@ function Admin() {
   return (
     <main className="flex flex-1 flex-col gap-4 p-4 sm:p-6">
       <h1 className="text-2xl font-semibold text-foreground">Admin</h1>
-      <Card>
-        <CardHeader>
-          <CardTitle>NFL data sync</CardTitle>
-          <CardDescription>
-            Manually trigger the same sync jobs the cron scheduler runs.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-3">
-          {NFL_SYNC_JOB_ROWS.map((row) => (
-            <SyncJobRow
-              key={row.job}
-              job={row.job}
-              label={row.label}
-              description={row.description}
-            />
-          ))}
-        </CardContent>
-      </Card>
+      <SyncJobsCard />
+      <SeasonsBrowser />
+      <GamesBrowser />
+      <TeamsBrowser />
     </main>
-  );
-}
-
-function SyncJobRow({
-  job,
-  label,
-  description,
-}: {
-  job: NflSyncJob;
-  label: string;
-  description: string;
-}) {
-  const runJob = useRunNflSyncJob();
-
-  return (
-    <div className="flex flex-col gap-2 rounded-lg border border-border p-3 sm:flex-row sm:items-center sm:justify-between">
-      <div className="flex flex-col gap-0.5">
-        <p className="text-sm font-medium text-foreground">{label}</p>
-        <p className="text-sm text-muted-foreground">{description}</p>
-      </div>
-      <Button
-        variant="outline"
-        size="sm"
-        disabled={runJob.isPending && runJob.variables === job}
-        onClick={() => runJob.mutate(job)}
-      >
-        Run
-      </Button>
-    </div>
   );
 }

--- a/apps/web/src/routes/_authed/admin/games.tsx
+++ b/apps/web/src/routes/_authed/admin/games.tsx
@@ -1,0 +1,33 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+import { GamesBrowser } from "@/components/admin/games-browser";
+
+const searchSchema = z.object({
+  // Selection lives in the URL so a specific slate is shareable while debugging
+  // a sync, and so the seasons browser can link straight to the week whose game
+  // count looks wrong. A week identifies its own season, so a link needs only
+  // `weekId`; `seasonId` alone covers "season chosen, no week yet".
+  seasonId: z.uuid().optional(),
+  weekId: z.uuid().optional(),
+});
+
+export const Route = createFileRoute("/_authed/admin/games")({
+  validateSearch: searchSchema,
+  component: AdminGames,
+});
+
+function AdminGames() {
+  const { seasonId, weekId } = Route.useSearch();
+  const navigate = Route.useNavigate();
+
+  return (
+    <GamesBrowser
+      seasonId={seasonId}
+      weekId={weekId}
+      // `replace` on both: browsing weeks is refining one view, not a trail of
+      // destinations to back-button through.
+      onSeasonChange={(next) => navigate({ search: { seasonId: next }, replace: true })}
+      onWeekChange={(next) => navigate({ search: { weekId: next }, replace: true })}
+    />
+  );
+}

--- a/apps/web/src/routes/_authed/admin/index.tsx
+++ b/apps/web/src/routes/_authed/admin/index.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { SyncJobsCard } from "@/components/admin/sync-jobs-card";
+
+// The default admin section: operations you run, versus the browsers you read.
+// The non-prod simulator control panel (SIM-7) joins this tab.
+export const Route = createFileRoute("/_authed/admin/")({
+  component: AdminJobs,
+});
+
+function AdminJobs() {
+  return <SyncJobsCard />;
+}

--- a/apps/web/src/routes/_authed/admin/route.tsx
+++ b/apps/web/src/routes/_authed/admin/route.tsx
@@ -1,16 +1,20 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link, Outlet } from "@tanstack/react-router";
 import { useMe } from "@/api/me";
 import { Button } from "@/components/ui/button";
-import { SyncJobsCard } from "@/components/admin/sync-jobs-card";
-import { TeamsBrowser } from "@/components/admin/teams-browser";
-import { SeasonsBrowser } from "@/components/admin/seasons-browser";
-import { GamesBrowser } from "@/components/admin/games-browser";
+import { TabNav, tabLinkProps } from "@/components/tab-nav";
 
 export const Route = createFileRoute("/_authed/admin")({
-  component: Admin,
+  component: AdminLayout,
 });
 
-function Admin() {
+/**
+ * The admin surface's shell: one home for the allowlist guard, so no child
+ * route can be reached without it, and the tab bar the sections hang off.
+ * Sections are routes rather than local tab state — each is deep-linkable
+ * (a week's game slate is worth sharing while debugging a sync), survives a
+ * refresh, and only the open section's queries run.
+ */
+function AdminLayout() {
   const me = useMe();
 
   if (me.isPending) {
@@ -46,10 +50,21 @@ function Admin() {
   return (
     <main className="flex flex-1 flex-col gap-4 p-4 sm:p-6">
       <h1 className="text-2xl font-semibold text-foreground">Admin</h1>
-      <SyncJobsCard />
-      <SeasonsBrowser />
-      <GamesBrowser />
-      <TeamsBrowser />
+      <TabNav label="Admin sections">
+        <Link to="/admin" activeOptions={{ exact: true }} {...tabLinkProps}>
+          Jobs
+        </Link>
+        <Link to="/admin/seasons" {...tabLinkProps}>
+          Seasons
+        </Link>
+        <Link to="/admin/games" {...tabLinkProps}>
+          Games
+        </Link>
+        <Link to="/admin/teams" {...tabLinkProps}>
+          Teams
+        </Link>
+      </TabNav>
+      <Outlet />
     </main>
   );
 }

--- a/apps/web/src/routes/_authed/admin/seasons.tsx
+++ b/apps/web/src/routes/_authed/admin/seasons.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { SeasonsBrowser } from "@/components/admin/seasons-browser";
+
+export const Route = createFileRoute("/_authed/admin/seasons")({
+  component: SeasonsBrowser,
+});

--- a/apps/web/src/routes/_authed/admin/teams.tsx
+++ b/apps/web/src/routes/_authed/admin/teams.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { TeamsBrowser } from "@/components/admin/teams-browser";
+
+export const Route = createFileRoute("/_authed/admin/teams")({
+  component: TeamsBrowser,
+});

--- a/apps/web/src/routes/_authed/discovery.tsx
+++ b/apps/web/src/routes/_authed/discovery.tsx
@@ -4,6 +4,7 @@ import type { DiscoveryLeague } from "@picksleagues/schemas";
 import { useDiscovery } from "@/api/discovery";
 import { useJoinPublicLeague } from "@/api/members";
 import { leagueModeLabel } from "@/lib/league";
+import { formatDateTime } from "@/lib/format";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -99,11 +100,7 @@ function DiscoveryLeagueCard({ league }: { league: DiscoveryLeague }) {
           </span>
           <span>{league.seasonYear}</span>
         </div>
-        <p>
-          {league.startsAt
-            ? `Starts ${new Date(league.startsAt).toLocaleString()}`
-            : "Start date TBD"}
-        </p>
+        <p>{league.startsAt ? `Starts ${formatDateTime(league.startsAt)}` : "Start date TBD"}</p>
         <Button
           size="lg"
           className="w-full justify-center"

--- a/apps/web/src/routes/_authed/index.tsx
+++ b/apps/web/src/routes/_authed/index.tsx
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 import { ChevronRightIcon } from "lucide-react";
 import { MEMBER_ROLE, type LeagueSummary } from "@picksleagues/schemas";
 import { useMyLeagues } from "@/api/leagues";
+import { formatDateTime } from "@/lib/format";
 import { leagueModeLabel } from "@/lib/league";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -128,11 +129,7 @@ function LeagueCard({ league }: { league: LeagueSummary }) {
             </span>
           )}
         </div>
-        <p>
-          {league.startsAt
-            ? `Starts ${new Date(league.startsAt).toLocaleString()}`
-            : "Start date TBD"}
-        </p>
+        <p>{league.startsAt ? `Starts ${formatDateTime(league.startsAt)}` : "Start date TBD"}</p>
         {/* Pick tables land in later epics — nothing to summarize yet. */}
         <p className="text-xs text-muted-foreground/70">Pick status coming soon</p>
       </CardContent>

--- a/apps/web/src/routes/_authed/leagues/$leagueId/route.tsx
+++ b/apps/web/src/routes/_authed/leagues/$leagueId/route.tsx
@@ -6,18 +6,11 @@ import { LeagueHeader } from "@/components/league/league-header";
 import { useLeague } from "@/api/leagues";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { cn } from "@/lib/utils";
+import { TabNav, tabLinkProps } from "@/components/tab-nav";
 
 export const Route = createFileRoute("/_authed/leagues/$leagueId")({
   component: LeagueLayout,
 });
-
-const tabLinkClassName =
-  "border-b-2 border-transparent px-1 pb-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring/50";
-const activeTabLinkClassName = cn(
-  tabLinkClassName,
-  "border-foreground font-medium text-foreground",
-);
 
 function LeagueLayout() {
   const { leagueId } = Route.useParams();
@@ -74,36 +67,22 @@ function LeagueLayout() {
             isCommissioner={league.data.myRole === MEMBER_ROLE.COMMISSIONER}
           />
 
-          <nav aria-label="League sections" className="flex gap-4 border-b border-border text-sm">
+          <TabNav label="League sections">
             <Link
               to="/leagues/$leagueId"
               params={{ leagueId }}
               activeOptions={{ exact: true }}
-              className={tabLinkClassName}
-              inactiveProps={{ className: "text-muted-foreground" }}
-              activeProps={{ className: activeTabLinkClassName, "aria-current": "page" }}
+              {...tabLinkProps}
             >
               Overview
             </Link>
-            <Link
-              to="/leagues/$leagueId/members"
-              params={{ leagueId }}
-              className={tabLinkClassName}
-              inactiveProps={{ className: "text-muted-foreground" }}
-              activeProps={{ className: activeTabLinkClassName, "aria-current": "page" }}
-            >
+            <Link to="/leagues/$leagueId/members" params={{ leagueId }} {...tabLinkProps}>
               Members
             </Link>
-            <Link
-              to="/leagues/$leagueId/settings"
-              params={{ leagueId }}
-              className={tabLinkClassName}
-              inactiveProps={{ className: "text-muted-foreground" }}
-              activeProps={{ className: activeTabLinkClassName, "aria-current": "page" }}
-            >
+            <Link to="/leagues/$leagueId/settings" params={{ leagueId }} {...tabLinkProps}>
               Settings
             </Link>
-          </nav>
+          </TabNav>
 
           <Outlet />
         </>

--- a/apps/web/src/routes/join.$code.tsx
+++ b/apps/web/src/routes/join.$code.tsx
@@ -5,6 +5,7 @@ import { JOIN_BLOCKED_REASON, JOIN_BLOCKED_REASON_MESSAGES } from "@picksleagues
 import { useJoinPreview } from "@/api/invites";
 import { useJoinByCode } from "@/api/members";
 import { authClient } from "@/lib/auth";
+import { formatDateTime } from "@/lib/format";
 import { leagueModeLabel } from "@/lib/league";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -105,7 +106,7 @@ function JoinByCode() {
             {league.startsAt && (
               <div className="flex justify-between gap-2">
                 <dt>Starts</dt>
-                <dd>{new Date(league.startsAt).toLocaleString()}</dd>
+                <dd>{formatDateTime(league.startsAt)}</dd>
               </div>
             )}
           </dl>

--- a/backlog/04-simulator-admin.md
+++ b/backlog/04-simulator-admin.md
@@ -7,7 +7,7 @@ The UI-driven testing and operations surface, merged from the former Simulator a
 ## Shell & data visibility (deps already met — buildable now)
 
 - [x] **ADM-1** — Admin role via env-var user-ID allowlist + admin page shell: manual job triggers, standings rebuild buttons (as those features land); hosts the sim control panel in non-prod. _(deps: DATA-3, FND-11)_
-- [ ] **ADM-4** — Read-only reference-data browsers on the admin page: teams, seasons/weeks, games (provider + override fields visible), odds snapshots. Doubles as verification for the sync jobs. _(deps: ADM-1)_
+- [x] **ADM-4** — Read-only reference-data browsers on the admin page: teams, seasons/weeks, games (provider + override fields visible), odds snapshots. Doubles as verification for the sync jobs. _(deps: ADM-1)_
 
 ## Simulator backend
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -337,6 +337,11 @@ GET    /leagues/:id/picks/week/:week     own always; others' filtered by kickoff
 GET/PATCH /me                            username claim/change, display name
 DELETE /me                               account deletion: anonymize in place (guarded by ADR-0004 once leagues exist)
 POST   /jobs/*                           secret-protected job triggers (prod cron)
+POST   /admin/jobs/nfl/:job              manual sync trigger from the admin page (ADR-0011)
+GET    /admin/teams                      ?sport= — read-only reference-data browsers
+GET    /admin/seasons                    ?sport= — seasons + weeks + per-week game counts
+GET    /admin/games                      ?weekId= — provider, override, and resolved values
+GET    /admin/games/:id/odds             recent spread snapshots for one game
 PUT    /admin/games/:id/override         set/clear overrides (admin allowlist; audited)
 POST   /admin/leagues/:id/rebuild        wipe + recompute results/standings
 POST   /sim/*                            simulator (non-prod only, admin allowlist; see Simulator section)

--- a/openapi/client/schema.d.ts
+++ b/openapi/client/schema.d.ts
@@ -284,6 +284,74 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/teams": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Browse synced teams for a sport */
+        get: operations["listAdminTeams"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/seasons": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Browse synced seasons and their weeks for a sport */
+        get: operations["listAdminSeasons"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/games": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Browse a week's games with provider, override, and resolved values */
+        get: operations["listAdminGames"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/games/{gameId}/odds": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Browse a game's most recent odds snapshots */
+        get: operations["listAdminGameOdds"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -531,6 +599,93 @@ export interface components {
         };
         /** @enum {string} */
         NflSyncJob: "sync-schedule" | "sync-odds" | "sync-scores";
+        AdminTeamsResponse: {
+            teams: components["schemas"]["AdminTeam"][];
+        };
+        AdminTeam: {
+            id: string;
+            sport: components["schemas"]["Sport"];
+            providerTeamId: string | null;
+            abbreviation: string;
+            name: string;
+            location: string | null;
+            logoLightUrl: string | null;
+            logoDarkUrl: string | null;
+            /** Format: date-time */
+            updatedAt: string;
+        };
+        /** @enum {string} */
+        Sport: "nfl" | "ncaamb";
+        AdminSeasonsResponse: {
+            seasons: components["schemas"]["AdminSeason"][];
+        };
+        AdminSeason: {
+            id: string;
+            sport: components["schemas"]["Sport"];
+            year: number;
+            provisional: boolean;
+            weeks: components["schemas"]["AdminWeek"][];
+        };
+        AdminWeek: {
+            id: string;
+            weekType: components["schemas"]["WeekType"];
+            weekNumber: number;
+            label: string;
+            /** Format: date-time */
+            startsAt: string;
+            /** Format: date-time */
+            endsAt: string;
+            gameCount: number;
+        };
+        AdminGamesResponse: {
+            games: components["schemas"]["AdminGame"][];
+        };
+        AdminGame: {
+            id: string;
+            weekId: string;
+            providerGameId: string;
+            homeTeam: components["schemas"]["AdminGameTeam"];
+            awayTeam: components["schemas"]["AdminGameTeam"];
+            /** Format: date-time */
+            kickoffAt: string;
+            status: components["schemas"]["GameStatus"];
+            homeScore: number | null;
+            awayScore: number | null;
+            latestSpread: number | null;
+            /** Format: date-time */
+            latestSpreadCapturedAt: string | null;
+            /** Format: date-time */
+            overrideKickoffAt: string | null;
+            overrideStatus: components["schemas"]["GameStatus"] & (string | null);
+            overrideHomeScore: number | null;
+            overrideAwayScore: number | null;
+            overrideSpread: number | null;
+            overriddenBy: string | null;
+            /** Format: date-time */
+            overriddenAt: string | null;
+            /** Format: date-time */
+            effectiveKickoffAt: string;
+            effectiveStatus: components["schemas"]["GameStatus"];
+            effectiveHomeScore: number | null;
+            effectiveAwayScore: number | null;
+            effectiveSpread: number | null;
+        };
+        AdminGameTeam: {
+            id: string;
+            abbreviation: string;
+            name: string;
+        };
+        /** @enum {string} */
+        GameStatus: "scheduled" | "in_progress" | "final" | "postponed" | "cancelled" | "moved";
+        AdminGameOddsResponse: {
+            snapshots: components["schemas"]["AdminOddsSnapshot"][];
+        };
+        AdminOddsSnapshot: {
+            id: string;
+            spread: number;
+            /** Format: date-time */
+            capturedAt: string;
+        };
     };
     responses: never;
     parameters: never;
@@ -1865,6 +2020,247 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["JobRunResponse"];
+                };
+            };
+        };
+    };
+    listAdminTeams: {
+        parameters: {
+            query: {
+                sport: components["schemas"]["Sport"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Every team row for the sport, ordered by abbreviation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminTeamsResponse"];
+                };
+            };
+            /** @description A request param failed its format rule */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description No valid session */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The caller is signed in but not on the admin allowlist */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server misconfiguration — structurally unreachable outside generate-openapi.ts, which builds the app with no deps and only ever requests the spec document, never invoking this handler. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    listAdminSeasons: {
+        parameters: {
+            query: {
+                sport: components["schemas"]["Sport"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Seasons newest-first, each with its weeks in chronological order */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminSeasonsResponse"];
+                };
+            };
+            /** @description A request param failed its format rule */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description No valid session */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The caller is signed in but not on the admin allowlist */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server misconfiguration — structurally unreachable outside generate-openapi.ts, which builds the app with no deps and only ever requests the spec document, never invoking this handler. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    listAdminGames: {
+        parameters: {
+            query: {
+                weekId: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The week's games ordered by resolved kickoff — empty for an unknown week id, which is indistinguishable from a week with no games synced yet */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminGamesResponse"];
+                };
+            };
+            /** @description A request param failed its format rule */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description No valid session */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The caller is signed in but not on the admin allowlist */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server misconfiguration — structurally unreachable outside generate-openapi.ts, which builds the app with no deps and only ever requests the spec document, never invoking this handler. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    listAdminGameOdds: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                gameId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The game's most recent spread snapshots, newest first */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminGameOddsResponse"];
+                };
+            };
+            /** @description A request param failed its format rule */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description No valid session */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The caller is signed in but not on the admin allowlist */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description No such game */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server misconfiguration — structurally unreachable outside generate-openapi.ts, which builds the app with no deps and only ever requests the spec document, never invoking this handler. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
         };

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -974,6 +974,395 @@
           "sync-odds",
           "sync-scores"
         ]
+      },
+      "AdminTeamsResponse": {
+        "type": "object",
+        "properties": {
+          "teams": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AdminTeam"
+            }
+          }
+        },
+        "required": [
+          "teams"
+        ]
+      },
+      "AdminTeam": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "sport": {
+            "$ref": "#/components/schemas/Sport"
+          },
+          "providerTeamId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "abbreviation": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "location": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "logoLightUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "logoDarkUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "sport",
+          "providerTeamId",
+          "abbreviation",
+          "name",
+          "location",
+          "logoLightUrl",
+          "logoDarkUrl",
+          "updatedAt"
+        ]
+      },
+      "Sport": {
+        "type": "string",
+        "enum": [
+          "nfl",
+          "ncaamb"
+        ]
+      },
+      "AdminSeasonsResponse": {
+        "type": "object",
+        "properties": {
+          "seasons": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AdminSeason"
+            }
+          }
+        },
+        "required": [
+          "seasons"
+        ]
+      },
+      "AdminSeason": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "sport": {
+            "$ref": "#/components/schemas/Sport"
+          },
+          "year": {
+            "type": "integer"
+          },
+          "provisional": {
+            "type": "boolean"
+          },
+          "weeks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AdminWeek"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "sport",
+          "year",
+          "provisional",
+          "weeks"
+        ]
+      },
+      "AdminWeek": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "weekType": {
+            "$ref": "#/components/schemas/WeekType"
+          },
+          "weekNumber": {
+            "type": "integer"
+          },
+          "label": {
+            "type": "string"
+          },
+          "startsAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endsAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "gameCount": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "weekType",
+          "weekNumber",
+          "label",
+          "startsAt",
+          "endsAt",
+          "gameCount"
+        ]
+      },
+      "AdminGamesResponse": {
+        "type": "object",
+        "properties": {
+          "games": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AdminGame"
+            }
+          }
+        },
+        "required": [
+          "games"
+        ]
+      },
+      "AdminGame": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "weekId": {
+            "type": "string"
+          },
+          "providerGameId": {
+            "type": "string"
+          },
+          "homeTeam": {
+            "$ref": "#/components/schemas/AdminGameTeam"
+          },
+          "awayTeam": {
+            "$ref": "#/components/schemas/AdminGameTeam"
+          },
+          "kickoffAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "$ref": "#/components/schemas/GameStatus"
+          },
+          "homeScore": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "awayScore": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "latestSpread": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "latestSpreadCapturedAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "overrideKickoffAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "overrideStatus": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GameStatus"
+              },
+              {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            ]
+          },
+          "overrideHomeScore": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "overrideAwayScore": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "overrideSpread": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "overriddenBy": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "overriddenAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "effectiveKickoffAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "effectiveStatus": {
+            "$ref": "#/components/schemas/GameStatus"
+          },
+          "effectiveHomeScore": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "effectiveAwayScore": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "effectiveSpread": {
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "weekId",
+          "providerGameId",
+          "homeTeam",
+          "awayTeam",
+          "kickoffAt",
+          "status",
+          "homeScore",
+          "awayScore",
+          "latestSpread",
+          "latestSpreadCapturedAt",
+          "overrideKickoffAt",
+          "overrideStatus",
+          "overrideHomeScore",
+          "overrideAwayScore",
+          "overrideSpread",
+          "overriddenBy",
+          "overriddenAt",
+          "effectiveKickoffAt",
+          "effectiveStatus",
+          "effectiveHomeScore",
+          "effectiveAwayScore",
+          "effectiveSpread"
+        ]
+      },
+      "AdminGameTeam": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "abbreviation": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "abbreviation",
+          "name"
+        ]
+      },
+      "GameStatus": {
+        "type": "string",
+        "enum": [
+          "scheduled",
+          "in_progress",
+          "final",
+          "postponed",
+          "cancelled",
+          "moved"
+        ]
+      },
+      "AdminGameOddsResponse": {
+        "type": "object",
+        "properties": {
+          "snapshots": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AdminOddsSnapshot"
+            }
+          }
+        },
+        "required": [
+          "snapshots"
+        ]
+      },
+      "AdminOddsSnapshot": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "spread": {
+            "type": "number"
+          },
+          "capturedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "spread",
+          "capturedAt"
+        ]
       }
     },
     "parameters": {}
@@ -2580,6 +2969,290 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/JobRunResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/teams": {
+      "get": {
+        "operationId": "listAdminTeams",
+        "summary": "Browse synced teams for a sport",
+        "parameters": [
+          {
+            "schema": {
+              "$ref": "#/components/schemas/Sport"
+            },
+            "required": true,
+            "name": "sport",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Every team row for the sport, ordered by abbreviation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminTeamsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "A request param failed its format rule",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No valid session",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The caller is signed in but not on the admin allowlist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server misconfiguration — structurally unreachable outside generate-openapi.ts, which builds the app with no deps and only ever requests the spec document, never invoking this handler.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/seasons": {
+      "get": {
+        "operationId": "listAdminSeasons",
+        "summary": "Browse synced seasons and their weeks for a sport",
+        "parameters": [
+          {
+            "schema": {
+              "$ref": "#/components/schemas/Sport"
+            },
+            "required": true,
+            "name": "sport",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Seasons newest-first, each with its weeks in chronological order",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminSeasonsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "A request param failed its format rule",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No valid session",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The caller is signed in but not on the admin allowlist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server misconfiguration — structurally unreachable outside generate-openapi.ts, which builds the app with no deps and only ever requests the spec document, never invoking this handler.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/games": {
+      "get": {
+        "operationId": "listAdminGames",
+        "summary": "Browse a week's games with provider, override, and resolved values",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "weekId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The week's games ordered by resolved kickoff — empty for an unknown week id, which is indistinguishable from a week with no games synced yet",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminGamesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "A request param failed its format rule",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No valid session",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The caller is signed in but not on the admin allowlist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server misconfiguration — structurally unreachable outside generate-openapi.ts, which builds the app with no deps and only ever requests the spec document, never invoking this handler.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/games/{gameId}/odds": {
+      "get": {
+        "operationId": "listAdminGameOdds",
+        "summary": "Browse a game's most recent odds snapshots",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "gameId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The game's most recent spread snapshots, newest first",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminGameOddsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "A request param failed its format rule",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No valid session",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The caller is signed in but not on the admin allowlist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such game",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server misconfiguration — structurally unreachable outside generate-openapi.ts, which builds the app with no deps and only ever requests the spec document, never invoking this handler.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/packages/schemas/src/admin-data.ts
+++ b/packages/schemas/src/admin-data.ts
@@ -1,0 +1,144 @@
+import { z } from "@hono/zod-openapi";
+import { GameStatusSchema } from "./game-status";
+import { SportSchema } from "./sport";
+import { WeekTypeSchema } from "./week-type";
+
+/**
+ * Read-only projections of the provider-synced reference tables for the admin
+ * page's data browsers (arch §Manual Sports Data Overrides: "read-only
+ * browsers over reference data — teams, seasons/weeks, games, odds
+ * snapshots"). These are inspection surfaces whose whole point is showing the
+ * raw stored truth, so DB columns are serialized flat rather than reshaped;
+ * `AdminGame` is the exception and carries provider, override, and resolved
+ * values side by side so an operator can see what ingestion wrote, what a human
+ * corrected, and what the app will actually use.
+ */
+
+export const AdminTeamSchema = z
+  .object({
+    id: z.string(),
+    sport: SportSchema,
+    // Null on bootstrap rows that predate provider linkage (see teams table).
+    providerTeamId: z.string().nullable(),
+    abbreviation: z.string(),
+    name: z.string(),
+    location: z.string().nullable(),
+    logoLightUrl: z.string().nullable(),
+    logoDarkUrl: z.string().nullable(),
+    updatedAt: z.iso.datetime(),
+  })
+  .openapi("AdminTeam");
+
+export type AdminTeam = z.infer<typeof AdminTeamSchema>;
+
+export const AdminTeamsResponseSchema = z
+  .object({ teams: z.array(AdminTeamSchema) })
+  .openapi("AdminTeamsResponse");
+
+export type AdminTeamsResponse = z.infer<typeof AdminTeamsResponseSchema>;
+
+export const AdminWeekSchema = z
+  .object({
+    id: z.string(),
+    weekType: WeekTypeSchema,
+    weekNumber: z.number().int(),
+    label: z.string(),
+    startsAt: z.iso.datetime(),
+    endsAt: z.iso.datetime(),
+    // The verification signal the browsers exist for: a synced week with zero
+    // games means the schedule sync didn't finish the job.
+    gameCount: z.number().int(),
+  })
+  .openapi("AdminWeek");
+
+export type AdminWeek = z.infer<typeof AdminWeekSchema>;
+
+export const AdminSeasonSchema = z
+  .object({
+    id: z.string(),
+    sport: SportSchema,
+    year: z.number().int(),
+    provisional: z.boolean(),
+    weeks: z.array(AdminWeekSchema),
+  })
+  .openapi("AdminSeason");
+
+export type AdminSeason = z.infer<typeof AdminSeasonSchema>;
+
+export const AdminSeasonsResponseSchema = z
+  .object({ seasons: z.array(AdminSeasonSchema) })
+  .openapi("AdminSeasonsResponse");
+
+export type AdminSeasonsResponse = z.infer<typeof AdminSeasonsResponseSchema>;
+
+export const AdminGameTeamSchema = z
+  .object({
+    id: z.string(),
+    abbreviation: z.string(),
+    name: z.string(),
+  })
+  .openapi("AdminGameTeam");
+
+export const AdminGameSchema = z
+  .object({
+    id: z.string(),
+    weekId: z.string(),
+    providerGameId: z.string(),
+    homeTeam: AdminGameTeamSchema,
+    awayTeam: AdminGameTeamSchema,
+    // Provider block — exactly what ingestion wrote, never override-resolved,
+    // so a browser can prove a re-sync didn't clobber a correction (arch D15).
+    kickoffAt: z.iso.datetime(),
+    status: GameStatusSchema,
+    homeScore: z.number().int().nullable(),
+    awayScore: z.number().int().nullable(),
+    // Latest odds snapshot for this game; null until the odds sync captures one.
+    latestSpread: z.number().nullable(),
+    latestSpreadCapturedAt: z.iso.datetime().nullable(),
+    // Override block — admin corrections only (ADM-2 writes these).
+    overrideKickoffAt: z.iso.datetime().nullable(),
+    overrideStatus: GameStatusSchema.nullable(),
+    overrideHomeScore: z.number().int().nullable(),
+    overrideAwayScore: z.number().int().nullable(),
+    overrideSpread: z.number().nullable(),
+    overriddenBy: z.string().nullable(),
+    overriddenAt: z.iso.datetime().nullable(),
+    // Resolved block — `override_* ?? provider_*` (arch D15). Serialized rather
+    // than left to the client so precedence has one home, not one per consumer.
+    effectiveKickoffAt: z.iso.datetime(),
+    effectiveStatus: GameStatusSchema,
+    effectiveHomeScore: z.number().int().nullable(),
+    effectiveAwayScore: z.number().int().nullable(),
+    effectiveSpread: z.number().nullable(),
+  })
+  .openapi("AdminGame");
+
+export type AdminGame = z.infer<typeof AdminGameSchema>;
+
+export const AdminGamesResponseSchema = z
+  .object({ games: z.array(AdminGameSchema) })
+  .openapi("AdminGamesResponse");
+
+export type AdminGamesResponse = z.infer<typeof AdminGamesResponseSchema>;
+
+export const AdminOddsSnapshotSchema = z
+  .object({
+    id: z.string(),
+    // Home-team-relative; negative = home favored (odds_snapshots.spread).
+    spread: z.number(),
+    capturedAt: z.iso.datetime(),
+  })
+  .openapi("AdminOddsSnapshot");
+
+export type AdminOddsSnapshot = z.infer<typeof AdminOddsSnapshotSchema>;
+
+// Snapshot history is unbounded over a season of 5-minute odds syncs, so the
+// browser reads the most recent page only — enough to see whether the spread is
+// moving and when it was last captured.
+export const ADMIN_ODDS_SNAPSHOT_LIMIT = 50;
+
+export const AdminGameOddsResponseSchema = z
+  .object({ snapshots: z.array(AdminOddsSnapshotSchema) })
+  .openapi("AdminGameOddsResponse");
+
+export type AdminGameOddsResponse = z.infer<typeof AdminGameOddsResponseSchema>;

--- a/packages/schemas/src/error.ts
+++ b/packages/schemas/src/error.ts
@@ -18,6 +18,7 @@ export const ERROR_CODE = {
   USERNAME_TAKEN: "username_taken",
   LAST_COMMISSIONER: "last_commissioner",
   LEAGUE_NOT_FOUND: "league_not_found",
+  GAME_NOT_FOUND: "game_not_found",
   NOT_COMMISSIONER: "not_commissioner",
   MEMBER_NOT_FOUND: "member_not_found",
   INVITE_NOT_FOUND: "invite_not_found",

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./admin-data";
 export * from "./discovery";
 export * from "./display-name";
 export * from "./error";


### PR DESCRIPTION
Closes **ADM-4** — read-only browsers over teams, seasons/weeks, games, and odds snapshots on the admin page. Per arch §Manual Sports Data Overrides, these double as the verification surface for the sync jobs.

## API

Four allowlist-gated GETs behind the existing `/admin/*` guards:

```
GET /admin/teams?sport=          teams for a sport, by abbreviation
GET /admin/seasons?sport=        seasons newest-first, weeks chronological, per-week game counts
GET /admin/games?weekId=         a week's games, ordered by resolved kickoff
GET /admin/games/{id}/odds       most recent spread snapshots (capped at 50)
```

`sport` is required rather than defaulting to all sports — NCAAMB lands with the March Madness epic and would otherwise silently double those lists.

The games projection carries **provider, override, and resolved values side by side**, so an operator can prove a re-sync didn't clobber a correction. Override precedence gets one home in `apps/api/src/services/games.ts` (arch D15) — the TS coalesce and its SQL form live together, and `leagueStartAt` was migrated onto it (it had been restating the same coalesce inline, which would have drifted from the serializers the moment precedence gained any nuance). ADM-2 and the settlement input loader inherit it.

## Web

Three browsers as cards in the existing page skeleton, mobile-first. The games browser annotates the provider value inline only on fields an override actually changed; odds history is a per-game disclosure that fetches lazily.

Running a sync job now invalidates the browser queries — previously a week stuck at "0 games" stayed stuck after a successful sync, making a real sync indistinguishable from a no-op. Teams carry `updatedAt` for the same reason.

Also included: `WeekSelect` (never week-specific) promoted to a shared generic `LabeledSelect` before the games browser made it copies three and four, and the four hand-rolled `toLocaleString` kickoff/deadline displays routed through `lib/format.ts`. Net −88 lines in `league-settings-fields.tsx`.

## Page structure

The admin surface is split into tabbed section routes under an `/admin` layout — one page carrying all four browsers rendered 9,129px tall at phone width, and the surface is scheduled to grow (SIM-7's simulator panel, ADM-2/ADM-3's override editing and audit view):

| Tab | Height @375px | Queries on open |
|---|---|---|
| Jobs | 900px | none |
| Seasons | 1,748px | seasons |
| Games | 3,394px | seasons + games |
| Teams | 4,418px | teams |

Routes rather than local tab state: each section is deep-linkable and survives a refresh, only the open section fetches (previously all three browsers fetched on mount), and the allowlist guard lives once in the layout.

The games browser's selection moved into the URL, which turns the one real cost of splitting — losing the ability to eyeball a suspicious week count and scroll to that week's slate — into a link. Every week row in Seasons points at `/admin/games?weekId=…`, and a week identifies its own season so the link carries nothing else. Past seasons collapse by default (~22 weeks each). The league layout's tab-bar chrome became a shared `TabNav` instead of a second copy.

## Testing

- **19 new integration tests** (232 total, 171 unit, all green). 401/403 on every surface, shapes, ordering, 404 vs. empty, and override precedence: provider columns survive a correction verbatim while resolved values follow `override_* ?? provider_*`.
- **Mutation-tested for non-vacuity.** Replacing `effectiveKickoffAtSql` with the plain provider column flips the ordering assertion. Removing the new odds tiebreak fails ~half of runs — a sync run stamps every row with one `clock.now()`, so equal `captured_at` is ordinary and under the simulator's fixed clock it's the norm; both `DISTINCT ON` and the `LIMIT` boundary were picking arbitrarily.
- **Runtime-verified** against real ESPN-synced local data (34 teams, 2 seasons × 22 weeks, 570 games) with a temporary override + odds fixture, since reverted. Confirmed provider/resolved split, latest-snapshot wins, resolved-kickoff reordering, 401/400/404, zero horizontal overflow at 375px, zero console errors, and that a triggered sync refetches all three browsers. Re-ran the create-league form to check the shared-select refactor.

## Review

Two adversarial evaluator passes. First surfaced 8 findings — all accepted and fixed, including the `leagueStartAt` restatement and the missing invalidation. Second pass returned no new findings; it diffed the emitted SQL of the old and new start-derivation expressions (byte-identical) and checked Postgres `uuid` ordering against JS string compare across 20k UUIDs (0 inversions) to confirm the tiebreak tests assert the right winner.

One known cosmetic edge, deliberately not fixed: a game with *exactly* 50 snapshots shows the "only the most recent 50 shown" note even though nothing was truncated. Fixing it properly means `limit(N+1)`-and-slice, which is more machinery than a one-value overstatement warrants.

## Docs

`docs/architecture.md` §API surface lists the new endpoints. No ADR — nothing here deviates from the locked v0.3 docs; arch already named these browsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
