### PR TITLE
fix(harness): Atlas guard false positives, plus two agent-guidance corrections

### DIFF
--- a/.atlas/manifest.json
+++ b/.atlas/manifest.json
@@ -2,7 +2,7 @@
   "atlas_version": "0.1.0",
   "human_only_states": [],
   "managed_files": {
-    ".claude/hooks/atlas/guard.py": "e7be13051e1dbb838346b866056d9cc550fb396a9273ba85a43e3f9296bfb365",
+    ".claude/hooks/atlas/guard.py": "620a3b14ce2588815e99d80d6d94e3f63db01cb659346bb9eedd5dc802476e19",
     ".githooks/commit-msg": "bdb83555533e7b09ab2753cdb0d30135a2a98dd9a56a954fdb265bfe37e869db",
     ".githooks/pre-commit": "070c54093c2a9bb0f274cc4e3d1f75043cd59d2bbb3884bf9262424a350e10af",
     ".githooks/pre-push": "94b6f2efb9becfd15c5a4d92c437ca2fadc72722f50564b662fd07c545e0ff09"

--- a/.claude/hooks/atlas/guard.py
+++ b/.claude/hooks/atlas/guard.py
@@ -140,6 +140,22 @@ def human_only_states() -> set[str]:
         return defaults
 
 
+# Between `git` and its subcommand, only global options may appear. Without this
+# anchor a rule like `\bgit\b.*\breset\b.*--hard\b` matches any command that
+# merely MENTIONS the words later on — `git log && echo "reset --hard"`, or a
+# commit message describing the rule — and denies it outright. Every git rule in
+# `denied` therefore matches at the subcommand position and confines its argument
+# scan to a single shell segment via `[^;&|]*`.
+#
+# Residual, deliberate: a quoted payload that itself reads `git clean -fd` still
+# denies, because `shell_tokens` flattens wrapper payloads so that
+# `bash -c "git clean -fd"` cannot slip through. That is the safe direction.
+GIT_SUB = (
+    r"\bgit\b(?:\s+(?:-[cC]\s+\S+|--(?:git-dir|work-tree|namespace|exec-path)=\S+"
+    r"|--no-pager|--paginate|--bare|--literal-pathspecs|--glob-pathspecs))*\s+"
+)
+
+
 def classify_command(command: str) -> tuple[str, str] | None:
     compact = " ".join(command.split())
     lowered = compact.lower()
@@ -156,6 +172,32 @@ def classify_command(command: str) -> tuple[str, str] | None:
         arguments = git_lower[1:]
         if subcommand == "reset" and "--hard" in arguments:
             return "deny", "git reset --hard destroys uncommitted work"
+        # Token-based, like `reset --hard` above, so `clean` is recognised as the
+        # SUBCOMMAND. The regex backstop below cannot tell the subcommand from a
+        # later mention of the word, which denied `git status && echo clean`.
+        if subcommand == "clean" and not any(
+            token == "--dry-run"
+            or (token.startswith("-") and not token.startswith("--") and "n" in token)
+            for token in arguments
+        ):
+            return "deny", "git clean can delete untracked work; use a dry run"
+        # `denied` patterns are matched against an already-lowercased string, so
+        # the regex alternative `\s-D\b` could never fire and `git branch -D` was
+        # not caught at all. The case-sensitive check belongs here, against the
+        # original-case tail.
+        if subcommand == "branch" and (
+            any(
+                argument == "-D"
+                or (
+                    argument.startswith("-")
+                    and not argument.startswith("--")
+                    and "D" in argument
+                )
+                for argument in git_tail[1:]
+            )
+            or ("--delete" in arguments and "--force" in arguments)
+        ):
+            return "deny", "force-deleting a branch can orphan work"
         if subcommand in {"commit", "push"} and "--no-verify" in arguments:
             return "deny", "--no-verify bypasses repository hooks"
         if subcommand == "push" and any(
@@ -188,41 +230,46 @@ def classify_command(command: str) -> tuple[str, str] | None:
                 )
 
     denied = (
-        (r"\bgit\b.*\breset\b.*--hard\b", "git reset --hard destroys uncommitted work"),
         (
-            r"\bgit\b.*\bclean\b(?![^;&|]*(?:--dry-run|\s-[a-z]*n))",
+            rf"{GIT_SUB}reset\b[^;&|]*--hard\b",
+            "git reset --hard destroys uncommitted work",
+        ),
+        (
+            rf"{GIT_SUB}clean\b(?![^;&|]*(?:--dry-run|\s-[a-z]*n))",
             "git clean can delete untracked work; use a dry run",
         ),
         (
-            r"\bgit\b.*\bcheckout\b\s+(?:head\s+)?--\s",
+            rf"{GIT_SUB}checkout\b\s+(?:head\s+)?--\s",
             "git checkout -- discards file changes",
         ),
         (
-            r"\bgit\b.*\brestore\b(?![^;&|]*(?:--staged|\s-[a-z]*s)(?![^;&|]*(?:--worktree|\s-[a-z]*w)))",
+            rf"{GIT_SUB}restore\b(?![^;&|]*(?:--staged|\s-[a-z]*s)(?![^;&|]*(?:--worktree|\s-[a-z]*w)))",
             "git restore can discard file changes",
         ),
         (
-            r"\bgit\b.*\bbranch\b.*(?:\s-D\b|--delete.*--force|--force.*--delete)",
+            # `-D` is handled case-sensitively in the token branch above; it
+            # cannot be expressed here, where matching is against lowered text.
+            rf"{GIT_SUB}branch\b[^;&|]*(?:--delete[^;&|]*--force|--force[^;&|]*--delete)",
             "force-deleting a branch can orphan work",
         ),
         (
-            r"\bgit\b.*\bstash\b\s+(?:drop|clear)\b",
+            rf"{GIT_SUB}stash\b\s+(?:drop|clear)\b",
             "dropping stashes destroys recoverable work",
         ),
         (
-            r"\bgit\b.*\b(?:commit|push)\b.*--no-verify\b",
+            rf"{GIT_SUB}(?:commit|push)\b[^;&|]*--no-verify\b",
             "--no-verify bypasses repository hooks",
         ),
         (
-            r"\bgit\b.*\bpush\b.*(?:--force(?:-with-lease)?|-f)\b",
+            rf"{GIT_SUB}push\b[^;&|]*(?:--force(?:-with-lease)?|-f)\b",
             "force-push is prohibited",
         ),
         (
-            r"\bgit\b.*\bremote\b\s+(?:add|remove|rename|set-url)\b",
+            rf"{GIT_SUB}remote\b\s+(?:add|remove|rename|set-url)\b",
             "remote changes require a human",
         ),
         (
-            r"\bgit\b.*\bconfig\b.*(?:credential|core\.hookspath|remote\.|url\.)",
+            rf"{GIT_SUB}config\b[^;&|]*(?:credential|core\.hookspath|remote\.|url\.)",
             "credential, hook-path, and remote configuration are guarded",
         ),
         (r"\b(?:gh\s+pr|glab\s+mr)\s+merge\b", "merging is a human action"),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ pnpm workspaces monorepo · Vite + React + TanStack Router/Query/Form SPA · Hon
 - **Decisions get recorded.** Any non-obvious architectural choice → `/adr`. If a choice contradicts `docs/architecture.md`, update that doc too.
 - Both docs are **locked at v0.3** and mutually reconciled — deviate only with a recorded reason (ADR), and keep them reconciled with each other.
 - **Time discipline is the repo's most load-bearing convention:** no raw `Date.now()`, no `new Date()` for "now", no SQL `now()` in domain logic — everything reads the injected `Clock` (arch D13). A lint rule enforces it from FND-6 on.
+- **The shell is zsh.** Quote a glob meant for the *tool* rather than the shell (`grep --include='*.ts'`) — unquoted, zsh tries to expand it first and the command dies with `no matches found`. In a compound command that `cd`s, use absolute paths afterwards: relative ones resolve against the new directory and fail quietly, which is how a capture ends up half-empty rather than obviously broken.
 
 ## Agent skills
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -140,6 +140,18 @@ any phase and cleared when the impediment lifts — it does not follow `[x] done
 - Drafts before approval: **true**.
 - Preview exact plan writes and transitions before publishing them. If drafts
   are not permitted, return the draft without presenting it as tracker state.
+- **Exception — Atlas execution.** Invoking `/atlas-implement` is itself the
+  approval to claim the tickets that work package names and to write its
+  execution records (`[EXECUTION PLAN]`, `[PROGRESS]`, `[AI CODE REVIEW]`,
+  `[CLOSEOUT]`). Those writes proceed without a preview — the human gate is the
+  PR review, and an autonomous run has nobody to preview them to. The preview
+  requirement still binds anything that changes a ticket's **text**, adds or
+  renumbers a ticket, or writes `[x]`.
+
+  This needs stating because the two rules otherwise contradict each other: the
+  skill treats invocation as approval to deliver, this document asks for a
+  preview first, and a run with no human watching resolves that conflict
+  arbitrarily.
 - Preserve stable ticket/spec requirements. Record evolving execution in
   `[EXECUTION PLAN]`, `[PROGRESS]`, `[SCOPE CHANGE]`, `[BLOCKED]`,
   `[AI CODE REVIEW]`, and `[CLOSEOUT]` records rather than silently rewriting


### PR DESCRIPTION
Applies the repository-level findings from `/atlas-improve`'s audit of work package
**simp-pr1** (169 turns, 16.5M cache-read tokens across the orchestrator and four workers).
Plugin-level findings were applied upstream in the local `atlas-plugin-v3` checkout.

Independent of #28 — different files, branched from `staging`.

## The guard bug

Every git rule in `.claude/hooks/atlas/guard.py` was shaped `\bgit\b.*\bSUBCOMMAND\b…`.
That `.*` spans the whole command line, so any command that merely **mentioned** a guarded
word was denied. In the audited session it fired four times with zero true positives:

| Command | Why it fired |
|---|---|
| `git status --short; …; echo "--- (the word) ---"` | the word appears anywhere after `git` |
| grepping transcripts for the denial text (×3) | the denial text contains the words |

It then blocked the commit message describing the fix, via the force-reset rule — the same
bug a fifth time — and blocked `git push …; gh pr create --base staging` a sixth, because
the protected-branch scan did not stop at `;`.

Rules now anchor at the **subcommand position** and confine argument scans to a single
shell segment. Wrapper payloads still deny, because the tokenizer flattens them, so a
`bash -c` wrapper around a destructive git command is refused exactly as before. A quoted
literal that reads as a real destructive command also still denies — deliberate, and the
safe direction, since the guard cannot tell prose from a payload.

### A real gap found while testing

Branch force-delete was **never caught**. The flag is uppercase, but `denied` patterns are
matched against an already-lowercased string, so that alternative could not fire under any
input. Confirmed against the original pattern before changing anything. The check moved to
the token branch, which retains original casing; the lowercase safe-delete flag still passes.

### Verification

Upstream regression tests cover both directions for every rule touched (58 plugin tests
green). The deployed copy here was then exercised through the real hook over a 31-command
matrix: every genuinely destructive command still denies, every safe variant and every prose
mention now passes. `.atlas/manifest.json`'s managed-file hash is updated to match.

## Two smaller corrections

**`docs/agents/issue-tracker.md`** — records that invoking `/atlas-implement` is itself the
approval to claim that work package's tickets and write its execution records. The document
asked for a preview of every tracker write while the skill treats invocation as approval to
deliver; in an autonomous run there is nobody to preview to, so the contradiction was being
resolved arbitrarily. Changing a ticket's text or writing `[x]` still needs a human.

**`CLAUDE.md`** — the shell is zsh: quote globs meant for the tool, and use absolute paths
after a `cd` in a compound command. Both cost a turn in the audited run; the second silently
produced a half-empty evidence capture that had to be regenerated.

`pnpm format:check` and `pnpm lint` green. No application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
