### PR TITLE
docs(testing): --dir does not scope a vitest run to one project

### DIFF
--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -31,6 +31,16 @@ rereading this guide.
 
 `verified` means the command ran successfully here. `inferred` means configuration names it but setup did not execute it. `unavailable` is an explicit gap.
 
+**Scoping a partial vitest run: use `--project`, never `--dir` or a bare path.**
+The two projects in `vitest.config.ts` are selected by name, and `--dir` is only a
+path filter applied *within every* project — so `vitest run --dir packages/scoring`
+still runs the `integration` project, whose `globalSetup` creates and migrates the
+test database. Confirmed: `vitest list --dir packages/scoring` enumerates both
+`[unit]` and `[integration]`; adding `--project unit` leaves only `[unit]`. Narrow
+with `vitest run --project unit <path>`. This matters because `--dir` reads like a
+scope filter and is not one, so a worker told to stay off the database can reach it
+while believing it has not.
+
 ## Evidence policy
 
 - Repository-local proof-artifact root: `docs/evidence/test-results`.


### PR DESCRIPTION
One docs fix from the `/atlas-improve` audit of work package `simp-pr2`.

A SIMP-4 worker was told to stay off the database, then ran `vitest run --dir packages/scoring` to get a red baseline. `--dir` filters paths *within every project* rather than selecting one, so the `integration` project ran too and its `globalSetup` reached local Postgres — 48 failures against a schema that was mid-migration, and a worker that believed it had honoured its packet.

Confirmed rather than taken from the worker's self-report:

```
vitest list --dir packages/scoring                   -> [unit] and [integration]
vitest list --dir packages/scoring --project unit    -> [unit] only
```

No behaviour change; `docs/agents/testing.md` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
